### PR TITLE
Update the vbuild that allows calling other lifecycle scripts

### DIFF
--- a/.github/actions/install-vbuild/action.yaml
+++ b/.github/actions/install-vbuild/action.yaml
@@ -1,0 +1,15 @@
+name: Install vbuild
+description: Install the vbuild tool
+
+runs:
+  using: composite
+  steps:
+    - name: Install vbuild
+      shell: bash
+      run: |
+        set -e
+        curl \
+          --location \
+          'https://github.com/Eeems/vbuild/releases/download/0.0.18/vbuild-vbuild-ubuntu' \
+          --output /usr/local/bin/vbuild
+        chmod +x /usr/local/bin/vbuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.package }}-noarch
           path: dist/noarch/${{ steps.pkgname.outputs.name }}-*.apk
@@ -253,7 +253,7 @@ jobs:
 
       - name: Upload artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.package }}-${{ matrix.arch }}
           path: dist/${{ matrix.arch }}/${{ steps.pkgname.outputs.name }}-*.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: .github/actions/install-vbuild
+      - uses: ./.github/actions/install-vbuild
 
       - name: Lint VELBUILD files
         run: |
@@ -160,7 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: .github/actions/install-vbuild
+      - uses: ./.github/actions/install-vbuild
 
       - &set-up-signing-key
         name: Set up signing key
@@ -240,7 +240,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: .github/actions/install-vbuild
+      - uses: ./.github/actions/install-vbuild
 
       - *set-up-signing-key
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           set -e
           curl \
             --location \
-            'https://github.com/Eeems/vbuild/releases/download/0.0.15/vbuild-vbuild-ubuntu' \
+            'https://github.com/Eeems/vbuild/releases/download/0.0.16/vbuild-vbuild-ubuntu' \
             --output /usr/local/bin/vbuild
           chmod +x /usr/local/bin/vbuild
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           set -e
           curl \
             --location \
-            'https://github.com/Eeems/vbuild/releases/download/0.0.17/vbuild-vbuild-ubuntu' \
+            'https://github.com/Eeems/vbuild/releases/download/0.0.18/vbuild-vbuild-ubuntu' \
             --output /usr/local/bin/vbuild
           chmod +x /usr/local/bin/vbuild
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,15 +135,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - &install-vbuild
-        name: Install vbuild
-        run: |
-          set -e
-          curl \
-            --location \
-            'https://github.com/Eeems/vbuild/releases/download/0.0.18/vbuild-vbuild-ubuntu' \
-            --output /usr/local/bin/vbuild
-          chmod +x /usr/local/bin/vbuild
+      - uses: .github/actions/install-vbuild
 
       - name: Lint VELBUILD files
         run: |
@@ -168,7 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - *install-vbuild
+      - uses: .github/actions/install-vbuild
 
       - &set-up-signing-key
         name: Set up signing key
@@ -248,7 +240,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - *install-vbuild
+      - uses: .github/actions/install-vbuild
 
       - *set-up-signing-key
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       multiarch: ${{ steps.generate-matrix.outputs.multiarch }}
       has_packages: ${{ steps.generate-matrix.outputs.has_packages }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -133,7 +133,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/install-vbuild
 
@@ -158,7 +158,7 @@ jobs:
         package: ${{ fromJson(needs.setup.outputs.noarch) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/install-vbuild
 
@@ -206,10 +206,10 @@ jobs:
           path: dist/noarch/${{ steps.pkgname.outputs.name }}-*.apk
           if-no-files-found: error
 
-      - &upload-to-s3
-        name: Upload to S3
+      - &configure-aws-credentials
+        name: Configure AWS Credentials
         if: github.repository == 'vellum-dev/vellum' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -238,7 +238,7 @@ jobs:
         arch: [aarch64, armv7]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/install-vbuild
 
@@ -259,7 +259,7 @@ jobs:
           path: dist/${{ matrix.arch }}/${{ steps.pkgname.outputs.name }}-*.apk
           if-no-files-found: warn
 
-      - *upload-to-s3
+      - *configure-aws-credentials
 
       - name: Upload packages to S3
         if: github.repository == 'vellum-dev/vellum' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
@@ -282,10 +282,10 @@ jobs:
         (github.ref == 'refs/heads/main' && github.event_name != 'pull_request')
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           set -e
           curl \
             --location \
-            'https://github.com/Eeems/vbuild/releases/download/0.0.16/vbuild-vbuild-ubuntu' \
+            'https://github.com/Eeems/vbuild/releases/download/0.0.17/vbuild-vbuild-ubuntu' \
             --output /usr/local/bin/vbuild
           chmod +x /usr/local/bin/vbuild
 

--- a/.github/workflows/cleanup-testing-repo.yml
+++ b/.github/workflows/cleanup-testing-repo.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove PR labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const labels = ['ready-for-review', 'testing-repo'];
@@ -33,11 +33,11 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get changed packages via API
         id: detect
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -69,7 +69,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: steps.detect.outputs.packages != ''
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify author and process command
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         with:
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify author and process command
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         with:
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove ready-for-review label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {

--- a/.github/workflows/testing-repo-commands.yml
+++ b/.github/workflows/testing-repo-commands.yml
@@ -150,14 +150,7 @@ jobs:
         with:
           ref: ${{ needs.check-command.outputs.pr_sha }}
 
-      - name: Install vbuild
-        run: |
-          set -e
-          curl \
-            --location \
-            'https://github.com/Eeems/vbuild/releases/download/0.0.11/vbuild-vbuild-ubuntu' \
-            --output /usr/local/bin/vbuild
-          chmod +x /usr/local/bin/vbuild
+      - uses: .github/actions/install-vbuild
 
       - name: Set up signing key
         run: |
@@ -201,14 +194,7 @@ jobs:
         with:
           ref: ${{ needs.check-command.outputs.pr_sha }}
 
-      - name: Install vbuild
-        run: |
-          set -e
-          curl \
-            --location \
-            'https://github.com/Eeems/vbuild/releases/download/0.0.11/vbuild-vbuild-ubuntu' \
-            --output /usr/local/bin/vbuild
-          chmod +x /usr/local/bin/vbuild
+      - uses: .github/actions/install-vbuild
 
       - name: Set up signing key
         run: |

--- a/.github/workflows/testing-repo-commands.yml
+++ b/.github/workflows/testing-repo-commands.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Get PR details
         id: pr
         if: steps.auth.outputs.authorized == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({
@@ -67,7 +67,7 @@ jobs:
 
       - name: React to command
         if: steps.auth.outputs.authorized == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           COMMAND: ${{ steps.parse.outputs.command }}
         with:
@@ -90,7 +90,7 @@ jobs:
       packages_list: ${{ steps.detect.outputs.packages_list }}
       has_packages: ${{ steps.detect.outputs.has_packages }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.check-command.outputs.pr_sha }}
           fetch-depth: 0
@@ -146,7 +146,7 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.detect-changes.outputs.noarch_packages) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.check-command.outputs.pr_sha }}
 
@@ -167,7 +167,7 @@ jobs:
 
       - &configure-aws-credentials
         name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -192,7 +192,7 @@ jobs:
         package: ${{ fromJson(needs.detect-changes.outputs.multiarch_packages) }}
         arch: [aarch64, armv7]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.check-command.outputs.pr_sha }}
 
@@ -219,7 +219,7 @@ jobs:
       needs.detect-changes.outputs.has_packages == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - *configure-aws-credentials
 
@@ -251,7 +251,7 @@ jobs:
         needs.remove-packages.result == 'failure')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - *set-up-signing-key
 
@@ -315,7 +315,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           COMMAND: ${{ needs.check-command.outputs.command }}
           NOARCH_PACKAGES: ${{ needs.detect-changes.outputs.noarch_packages || '[]' }}

--- a/.github/workflows/testing-repo-commands.yml
+++ b/.github/workflows/testing-repo-commands.yml
@@ -152,7 +152,8 @@ jobs:
 
       - uses: .github/actions/install-vbuild
 
-      - name: Set up signing key
+      - &set-up-signing-key
+        name: Set up signing key
         run: |
           if [ -n "$SIGNING_KEY" ]; then
             echo "$SIGNING_KEY" > keys/packages.rsa
@@ -164,7 +165,8 @@ jobs:
       - name: Build ${{ matrix.package }}
         run: ./scripts/build-package.sh "${{ matrix.package }}"
 
-      - name: Configure AWS credentials
+      - &configure-aws-credentials
+        name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -196,24 +198,12 @@ jobs:
 
       - uses: .github/actions/install-vbuild
 
-      - name: Set up signing key
-        run: |
-          if [ -n "$SIGNING_KEY" ]; then
-            echo "$SIGNING_KEY" > keys/packages.rsa
-            chmod 600 keys/packages.rsa
-          fi
-        env:
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      - *set-up-signing-key
 
       - name: Build ${{ matrix.package }} (${{ matrix.arch }})
         run: ./scripts/build-package.sh "${{ matrix.package }}" "${{ matrix.arch }}"
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
+      - *configure-aws-credentials
 
       - name: Upload to S3
         run: |
@@ -231,12 +221,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
+      - *configure-aws-credentials
 
       - name: Remove packages from S3
         env:
@@ -268,21 +253,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up signing key
-        run: |
-          if [ -n "$SIGNING_KEY" ]; then
-            echo "$SIGNING_KEY" > keys/packages.rsa
-            chmod 600 keys/packages.rsa
-          fi
-        env:
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      - *set-up-signing-key
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
+      - *configure-aws-credentials
 
       - name: Regenerate APKINDEX
         run: |

--- a/.github/workflows/testing-repo-commands.yml
+++ b/.github/workflows/testing-repo-commands.yml
@@ -150,7 +150,7 @@ jobs:
         with:
           ref: ${{ needs.check-command.outputs.pr_sha }}
 
-      - uses: .github/actions/install-vbuild
+      - uses: ./.github/actions/install-vbuild
 
       - &set-up-signing-key
         name: Set up signing key
@@ -196,7 +196,7 @@ jobs:
         with:
           ref: ${{ needs.check-command.outputs.pr_sha }}
 
-      - uses: .github/actions/install-vbuild
+      - uses: ./.github/actions/install-vbuild
 
       - *set-up-signing-key
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ packages-metadata.json
 tmp.json
 packages/*/pkg/
 packages/*/*.pre-deinstall
+packages/*/*.post-install
+packages/*/*.post-os-upgrade
+packages/*/*.post-upgrade

--- a/README.md
+++ b/README.md
@@ -164,8 +164,7 @@ postinstall(){
 }
 
 postupgrade(){
-	# Call postinstall
-	/home/root/.vellum/share/my-package/my-package.post-install
+	postinstall
 }
 
 predeinstall(){
@@ -216,7 +215,7 @@ postinstall(){
 }
 
 postupgrade(){
-	/home/root/.vellum/share/mypackage/mypackage.post-install
+	postinstall
 }
 
 postosupgrade(){

--- a/packages/entware-rc/VELBUILD
+++ b/packages/entware-rc/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=entware-rc
 pkgver=0.1
-pkgrel=1
+pkgrel=3
 pkgdesc="Manage entware installed services"
 upstream_author="toltec-dev"
 category="utilities"

--- a/packages/entware-rc/VELBUILD
+++ b/packages/entware-rc/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=entware-rc
 pkgver=0.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Manage entware installed services"
 upstream_author="toltec-dev"
 category="utilities"

--- a/packages/entware-rc/VELBUILD
+++ b/packages/entware-rc/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=entware-rc
 pkgver=0.1
-pkgrel=2
+pkgrel=1
 pkgdesc="Manage entware installed services"
 upstream_author="toltec-dev"
 category="utilities"

--- a/packages/entware-rc/VELBUILD
+++ b/packages/entware-rc/VELBUILD
@@ -28,7 +28,7 @@ package() {
 	install -D -m 755 -t "$pkgdir"/home/root/.vellum/bin/ \
 		"$srcdir"/rcctl
 }
-postinstall(){
+postinstall() {
 	/home/root/.vellum/bin/mount-rw
 	cp /home/root/.vellum/share/entware-rc/entware-rc@.service /etc/systemd/system/
 	systemctl daemon-reload
@@ -37,14 +37,14 @@ postinstall(){
 	echo ""
 	echo "You can use rcctl to manage services installed by entware"
 }
-postupgrade(){
-	/home/root/.vellum/share/entware-rc/entware-rc.post-install
+postupgrade() {
+	postinstall
 }
-postosupgrade(){
-	cp /home/root/.vellum/share/entware-rc/entware-rc.service /etc/systemd/system/
+postosupgrade() {
+	cp /home/root/.vellum/share/entware-rc/entware-rc@.service /etc/systemd/system/
 	systemctl daemon-reload
 }
-predeinstall(){
+predeinstall() {
 	/home/root/.vellum/bin/mount-rw
 	/home/root/.vellum/bin/rcctl list | xargs -I {} systemctl disable --now entware-rc@{}
 	rm -f /etc/systemd/system/entware-rc@.service

--- a/packages/entware-rc/VELBUILD
+++ b/packages/entware-rc/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=entware-rc
 pkgver=0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Manage entware installed services"
 upstream_author="toltec-dev"
 category="utilities"


### PR DESCRIPTION
- Allow calling other lifecycle scripts by the function name used in VELBUILD
- Ensure that publish/unpublish calls use the same version of vbuild
- Fix issue where post-os-upgrade scripts for subpackages were being placed in the wrong directory
- Update actions to latest versions based on deprecation warnings. There is still one action without an update available that will become problematic in september.