### PR TITLE
Update vbuild to 0.0.22

### DIFF
--- a/.github/actions/install-vbuild/action.yaml
+++ b/.github/actions/install-vbuild/action.yaml
@@ -10,6 +10,6 @@ runs:
         set -e
         curl \
           --location \
-          'https://github.com/Eeems/vbuild/releases/download/0.0.20/vbuild-vbuild-ubuntu' \
+          'https://github.com/Eeems/vbuild/releases/download/0.0.21/vbuild-vbuild-ubuntu' \
           --output /usr/local/bin/vbuild
         chmod +x /usr/local/bin/vbuild

--- a/.github/actions/install-vbuild/action.yaml
+++ b/.github/actions/install-vbuild/action.yaml
@@ -10,6 +10,6 @@ runs:
         set -e
         curl \
           --location \
-          'https://github.com/Eeems/vbuild/releases/download/0.0.21/vbuild-vbuild-ubuntu' \
+          'https://github.com/Eeems/vbuild/releases/download/0.0.22/vbuild-vbuild-ubuntu' \
           --output /usr/local/bin/vbuild
         chmod +x /usr/local/bin/vbuild

--- a/.github/actions/install-vbuild/action.yaml
+++ b/.github/actions/install-vbuild/action.yaml
@@ -10,6 +10,6 @@ runs:
         set -e
         curl \
           --location \
-          'https://github.com/Eeems/vbuild/releases/download/0.0.18/vbuild-vbuild-ubuntu' \
+          'https://github.com/Eeems/vbuild/releases/download/0.0.20/vbuild-vbuild-ubuntu' \
           --output /usr/local/bin/vbuild
         chmod +x /usr/local/bin/vbuild

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ packages-metadata.json
 tmp.json
 packages/*/pkg/
 packages/*/*.pre-deinstall
+packages/*/*.post-deinstall
 packages/*/*.post-install
 packages/*/*.post-os-upgrade
 packages/*/*.post-upgrade
+packages/*/*.pre-upgrade

--- a/README.md
+++ b/README.md
@@ -203,33 +203,12 @@ mount-restore  # Restore /etc overlay and remount root read-only
 ```
 It automatically detects if mount changes are required by the device.
 
-Example for a package with a systemd service:
+Example:
 
 ```sh
-postinstall(){
+postinstall() {
 	/home/root/.vellum/bin/mount-rw
-	cp /home/root/.vellum/share/mypackage/mypackage.service /etc/systemd/system/
-	systemctl daemon-reload
-	systemctl enable --now mypackage
-	/home/root/.vellum/bin/mount-restore
-}
-
-postupgrade(){
-	postinstall
-}
-
-postosupgrade(){
-	# mount-rw/mount-restore handled by vellum reenable
-	cp /home/root/.vellum/share/mypackage/mypackage.service /etc/systemd/system/
-	systemctl daemon-reload
-	systemctl enable --now mypackage
-}
-
-predeinstall(){
-	/home/root/.vellum/bin/mount-rw
-	systemctl disable --now mypackage 2>/dev/null || true
-	rm -f /etc/systemd/system/mypackage.service
-	systemctl daemon-reload
+	echo "tun" > /etc/modules-load.d/tun.conf
 	/home/root/.vellum/bin/mount-restore
 }
 ```

--- a/packages/entware-rc/VELBUILD
+++ b/packages/entware-rc/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=entware-rc
 pkgver=0.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Manage entware installed services"
 upstream_author="toltec-dev"
 category="utilities"

--- a/packages/entware-rc/VELBUILD
+++ b/packages/entware-rc/VELBUILD
@@ -16,6 +16,9 @@ entware-rc@.service::https://raw.githubusercontent.com/toltec-dev/toltec/$_commi
 rcctl::https://raw.githubusercontent.com/toltec-dev/toltec/$_commit/package/entware-rc/rcctl
 LICENSE::https://raw.githubusercontent.com/toltec-dev/toltec/refs/heads/stable/LICENSE
 "
+systemdunits='
+entware-rc@.service
+'
 
 package() {
 	install -Dm644 "$srcdir/LICENSE" \
@@ -23,16 +26,10 @@ package() {
 	echo "https://github.com/$upstream_author/toltec/tree/stable/package/entware-rc" > \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
 
-	install -D -m 666 -t "$pkgdir"/home/root/.vellum/share/$pkgname/ \
-		"$srcdir"/entware-rc@.service
 	install -D -m 755 -t "$pkgdir"/home/root/.vellum/bin/ \
 		"$srcdir"/rcctl
 }
 postinstall() {
-	/home/root/.vellum/bin/mount-rw
-	cp /home/root/.vellum/share/entware-rc/entware-rc@.service /etc/systemd/system/
-	systemctl daemon-reload
-	/home/root/.vellum/bin/mount-restore
 	/opt/bin/opkg install findutils
 	echo ""
 	echo "You can use rcctl to manage services installed by entware"
@@ -40,16 +37,8 @@ postinstall() {
 postupgrade() {
 	postinstall
 }
-postosupgrade() {
-	cp /home/root/.vellum/share/entware-rc/entware-rc@.service /etc/systemd/system/
-	systemctl daemon-reload
-}
 predeinstall() {
-	/home/root/.vellum/bin/mount-rw
-	/home/root/.vellum/bin/rcctl list | xargs -I {} systemctl disable --now entware-rc@{}
-	rm -f /etc/systemd/system/entware-rc@.service
-	systemctl daemon-reload
-	/home/root/.vellum/bin/mount-restore
+	/home/root/.vellum/bin/rcctl list | xargs -I {} systemctl stop entware-rc@{}
 }
 
 sha512sums="

--- a/packages/tailscale/VELBUILD
+++ b/packages/tailscale/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Interloper <45214659+0xdeb7ef@users.noreply.github.com>"
 pkgname=tailscale
 pkgver=1.96.2
-pkgrel=0
+pkgrel=1
 upstream_author="tailscale"
 category="utilities"
 pkgdesc="Tailscale VPN client"

--- a/packages/tailscale/VELBUILD
+++ b/packages/tailscale/VELBUILD
@@ -17,9 +17,11 @@ https://dl.tailscale.com/stable/tailscale_${pkgver}_arm64.tgz
 https://raw.githubusercontent.com/tailscale/tailscale/refs/tags/v$pkgver/LICENSE
 10-defaults.patch
 10-service.patch
-$pkgname.post-os-upgrade
 "
 builddir="$srcdir/tailscale"
+systemdunits='
+tailscale/systemd/tailscaled.service
+'
 
 unpack() {
 	if [ -z "$force" ]; then
@@ -56,76 +58,9 @@ package() {
 
 	install -Dm644 systemd/tailscaled.defaults \
 		"$pkgdir/home/root/.vellum/etc/default/tailscaled"
-
-	# install a backup .service file for use with post-os-upgrade
-	install -Dm644 systemd/tailscaled.service \
-		"$pkgdir/home/root/.vellum/share/tailscale/systemd/tailscaled.service"
 }
 
-postinstall() {
-	/home/root/.vellum/bin/mount-rw
-
-	echo "installing tailscaled.service..."
-	cp /home/root/.vellum/share/tailscale/systemd/tailscaled.service /etc/systemd/system/tailscaled.service
-
-	echo "reloading systemd daemon"
-	systemctl daemon-reload
-
-	echo "enabling tailscaled service..."
-	systemctl enable tailscaled.service
-
-	/home/root/.vellum/bin/mount-restore
-
-	echo "restarting tailscaled service..."
-	systemctl restart tailscaled.service
-}
-
-postupgrade() {
-	/home/root/.vellum/bin/mount-rw
-
-	echo "installing tailscaled.service..."
-	cp /home/root/.vellum/share/tailscale/systemd/tailscaled.service /etc/systemd/system/tailscaled.service
-
-	echo "reloading systemd daemon"
-	systemctl daemon-reload
-
-	echo "enabling tailscaled service..."
-	systemctl enable tailscaled.service
-
-	/home/root/.vellum/bin/mount-restore
-
-	echo "restarting tailscaled service..."
-	systemctl restart tailscaled.service
-}
-
-postosupgrade() {
-	echo " * re-installing tailscaled.service..."
-	cp /home/root/.vellum/share/tailscale/systemd/tailscaled.service /etc/systemd/system/tailscaled.service
-
-	echo " * reloading systemd daemon"
-	systemctl daemon-reload
-
-	echo " * enabling tailscaled service..."
-	systemctl enable tailscaled.service
-
-	echo " * restarting tailscaled service..."
-	systemctl restart tailscaled.service
-}
-
-predeinstall() {
-	/home/root/.vellum/bin/mount-rw
-
-	echo "stopping tailscaled service..."
-	systemctl disable --now tailscaled.service
-
-	echo "removing tailscaled.service..."
-	rm -f /etc/systemd/system/tailscaled.service
-
-	/home/root/.vellum/bin/mount-restore
-
-	echo "reloading systemd daemon"
-	systemctl daemon-reload
-
+postdeinstall() {
 	if [ "$VELLUM_PURGE" = "1" ]; then
 		echo "deleting tailscale config files..."
 		rm -rf \
@@ -140,5 +75,4 @@ f73f424d37f958e9d2bba0efa4878e10ff47da1f613d1babe56ef1c84e738439a2a94e94858075de
 0d6d4be4907d6994e0fe6aa10aee9e168608a41b0c0c32f4770830716312bf92756bb3cc294ad2419f02383317e68043d2e804231f150813af63da62c0556eb0  LICENSE
 b0cbcd5e94001fc8f91ae6bc0dca40bac8f34d92112d2a0ad83189c8e6bb79fe415dce9dda6a554c8094a59f1bfd6bf1109439c47ef5f1d0b3eb522af3a62c95  10-defaults.patch
 c2f12c405d9a63829c0d0a18757f29c8f295dd5de7dcfea3ac5875c0871d6af439cc25edb72c58881f29231c1a254a2488344d57861d1be49123228f8cdf6bd5  10-service.patch
-2100dd4f6936569ea683d6cec4e55a5d5940edb9dd9a4f75dff5faa1a7037af3c817a1a6987796f4ad96d2958b8943ebb236141f359428520d57a760f36a58aa  tailscale.post-os-upgrade
 '

--- a/packages/tailscale/VELBUILD
+++ b/packages/tailscale/VELBUILD
@@ -30,8 +30,12 @@ unpack() {
 	fi
 
 	case "$CARCH" in
-		aarch64) _arch="arm64" ;;
-		armv7) _arch="arm" ;;
+	aarch64) _arch="arm64" ;;
+	armv7) _arch="arm" ;;
+	*)
+		echo "Invalid CARCH: $CARCH"
+		exit 1
+		;;
 	esac
 
 	mkdir -p "$srcdir"

--- a/packages/tripletap/VELBUILD
+++ b/packages/tripletap/VELBUILD
@@ -15,18 +15,21 @@ LICENSE::https://raw.githubusercontent.com/rmitchellscott/xovi-tripletap/v$pkgve
 "
 options="!check !fhs !strip !tracedeps"
 builddir="$srcdir/xovi-tripletap-$pkgver"
+systemdunits="
+xovi-tripletap-$pkgver/xovi-tripletap.service
+"
 
 package() {
 	local install_dir="$pkgdir/home/root/xovi-tripletap"
 	mkdir -p "$install_dir"
 
 	case "$CARCH" in
-		aarch64)
-			install -Dm755 evtest.arm64 "$install_dir/evtest"
-			;;
-		armv7)
-			install -Dm755 evtest.arm32 "$install_dir/evtest"
-			;;
+	aarch64)
+		install -Dm755 evtest.arm64 "$install_dir/evtest"
+		;;
+	armv7)
+		install -Dm755 evtest.arm32 "$install_dir/evtest"
+		;;
 	esac
 
 	install -Dm755 main.sh "$install_dir/main.sh"
@@ -41,9 +44,7 @@ package() {
 	install -Dm644 config.default "$install_dir/config.default"
 	install -Dm755 migrate-to-config.sh "$install_dir/migrate-to-config.sh"
 
-	install -Dm644 xovi-tripletap.service "$install_dir/xovi-tripletap.service"
-
-	echo "$pkgver" > "$install_dir/version.txt"
+	echo "$pkgver" >"$install_dir/version.txt"
 
 	install -Dm644 "$srcdir/LICENSE" \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"
@@ -51,11 +52,11 @@ package() {
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
 }
 
-postinstall(){
+postinstall() {
 	/home/root/xovi-tripletap/enable.sh
 }
 
-preupgrade(){
+preupgrade() {
 	CONFIG_FILE="/home/root/xovi-tripletap/config"
 	MAIN_SH="/home/root/xovi-tripletap/main.sh"
 
@@ -78,7 +79,7 @@ preupgrade(){
 	TIME_THRESHOLD=${TIME_THRESHOLD:-$DEFAULT_TIME_THRESHOLD}
 	REQUIRED_PRESSES=${REQUIRED_PRESSES:-$DEFAULT_REQUIRED_PRESSES}
 
-	cat > "$CONFIG_FILE" << EOF
+	cat >"$CONFIG_FILE" <<EOF
 ENABLE_VERSION_SWITCHING=${ENABLE_VERSION_SWITCHING}
 TRIGGER_ACTION=${TRIGGER_ACTION}
 TIME_THRESHOLD=${TIME_THRESHOLD}
@@ -88,31 +89,18 @@ POST_START_COMMANDS=()
 EOF
 }
 
-postupgrade(){
+postupgrade() {
 	/home/root/xovi-tripletap/enable.sh
 }
 
-postosupgrade(){
-	cp /home/root/xovi-tripletap/xovi-tripletap.service /etc/systemd/system/
-	systemctl daemon-reload
-	systemctl enable xovi-tripletap --now
-}
-
-predeinstall(){
+predeinstall() {
 	/home/root/.vellum/bin/mount-rw
 
 	if [ "$VELLUM_PURGE" = "1" ]; then
 		/home/root/xovi-tripletap/uninstall.sh
-	else
-		systemctl stop xovi-tripletap 2>/dev/null || true
-		systemctl disable xovi-tripletap 2>/dev/null || true
-		rm -f /etc/systemd/system/xovi-tripletap.service
-		systemctl daemon-reload
-
-		if [ -f /home/root/xovi-tripletap/config ]; then
-			echo "Note: /home/root/xovi-tripletap/config preserved"
-			echo "      Use 'vellum purge tripletap' to remove everything"
-		fi
+	elif [ -f /home/root/xovi-tripletap/config ]; then
+		echo "Note: /home/root/xovi-tripletap/config preserved"
+		echo "      Use 'vellum purge tripletap' to remove everything"
 	fi
 
 	/home/root/.vellum/bin/mount-restore

--- a/packages/tripletap/VELBUILD
+++ b/packages/tripletap/VELBUILD
@@ -30,6 +30,10 @@ package() {
 	armv7)
 		install -Dm755 evtest.arm32 "$install_dir/evtest"
 		;;
+	*)
+		echo "Invalid CARCH: $CARCH"
+		exit 1
+		;;
 	esac
 
 	install -Dm755 main.sh "$install_dir/main.sh"

--- a/packages/tripletap/VELBUILD
+++ b/packages/tripletap/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Mitchell Scott <mitchell@scottlabs.io>"
 pkgname=tripletap
 pkgver=1.0.0
-pkgrel=1
+pkgrel=2
 upstream_author="rmitchellscott"
 category="utilities"
 pkgdesc="Start xovi by triple-pressing the power button"

--- a/packages/tripletap/VELBUILD
+++ b/packages/tripletap/VELBUILD
@@ -56,10 +56,6 @@ package() {
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
 }
 
-postinstall() {
-	/home/root/xovi-tripletap/enable.sh
-}
-
 preupgrade() {
 	CONFIG_FILE="/home/root/xovi-tripletap/config"
 	MAIN_SH="/home/root/xovi-tripletap/main.sh"
@@ -91,10 +87,6 @@ REQUIRED_PRESSES=${REQUIRED_PRESSES}
 PRE_START_COMMANDS=()
 POST_START_COMMANDS=()
 EOF
-}
-
-postupgrade() {
-	/home/root/xovi-tripletap/enable.sh
 }
 
 predeinstall() {


### PR DESCRIPTION
- When calling another lifecycle script, you can pass arguments. You should keep to passing only the arguments specified in [APKBUILD(5)](https://man.archlinux.org/man/APKBUILD.5.en#Install_Scripts).
- Caches are no longer shared between build directories. They are still stored in ~/.cache/vbuild/distfiles, but are now stored in a folder with the sha256sum of the abspath being acted on.
- You can now use `systemdunits` to list the systemd unit files relative to the `$srcdir` to automatically install, enable, start, stop, disable as part of the lifecycle. If you provide a template unit, it will install and disable, but will require you to manually do any start/stop/enable logic in the lifecycle scripts.