### PR TITLE
Update to vbuild 0.0.23 and add netevent

### DIFF
--- a/.github/actions/install-vbuild/action.yaml
+++ b/.github/actions/install-vbuild/action.yaml
@@ -10,6 +10,6 @@ runs:
         set -e
         curl \
           --location \
-          'https://github.com/Eeems/vbuild/releases/download/0.0.22/vbuild-vbuild-ubuntu' \
+          'https://github.com/Eeems/vbuild/releases/download/0.0.23/vbuild-vbuild-ubuntu' \
           --output /usr/local/bin/vbuild
         chmod +x /usr/local/bin/vbuild

--- a/.github/actions/install-vbuild/action.yaml
+++ b/.github/actions/install-vbuild/action.yaml
@@ -10,6 +10,6 @@ runs:
         set -e
         curl \
           --location \
-          'https://github.com/Eeems/vbuild/releases/download/0.0.23/vbuild-vbuild-ubuntu' \
+          'https://github.com/Eeems/vbuild/releases/download/0.0.23/vbuild-x86_64-glibc' \
           --output /usr/local/bin/vbuild
         chmod +x /usr/local/bin/vbuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
 
           # Get all multiarch packages
           all_multiarch=$(for pkg in packages/*/VELBUILD; do
-            if grep -qE '^arch="(aarch64|armv7|aarch64 armv7)"' "$pkg"; then
+            if grep -qE '^arch="(aarch64|armv7|aarch64 armv7|armv7 aarch64)"' "$pkg"; then
               basename $(dirname "$pkg")
             fi
           done)

--- a/packages/netevent/VELBUILD
+++ b/packages/netevent/VELBUILD
@@ -1,0 +1,40 @@
+maintainer="Nathaniel van Diepen <eeems@eeems.email>"
+pkgname=netevent
+pkgver=2.2.2
+pkgrel=0
+pkgdesc="Input-Event device cloning utility"
+upstream_author="Blub"
+category="utilities"
+url="https://github.com/Blub/netevent"
+arch="armv7 aarch64"
+license="GPL-2.0-only"
+source="$pkgname-${pkgver%-*}.tar.gz::https://github.com/$upstream_author/netevent/archive/refs/tags/${pkgver%-*}.tar.gz"
+options="!check !fhs !strip !tracedeps"
+
+image="ghcr.io/toltec-dev/base:v4.0"
+build() {
+	case "$CARCH" in
+	aarch64) . /opt/x-tools/switch-aarch64.sh ;;
+	armv7) . /opt/x-tools/switch-arm.sh ;;
+	*)
+		echo "Invalid CARCH: $CARCH"
+		exit 1
+		;;
+	esac
+	cd "$srcdir/$pkgname-${pkgver%-*}"
+	export CXX="${CROSS_COMPILE}g++"
+	make
+	"${CROSS_COMPILE}strip" netevent
+}
+
+package() {
+	cd "$srcdir/$pkgname-${pkgver%-*}"
+	install -Dm644 "LICENSE" \
+		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"
+	echo "https://github.com/$upstream_author/$pkgname" > \
+		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
+
+	install -D -m 755 netevent "$pkgdir"/home/root/.vellum/bin/netevent
+}
+sha512sums='bd993529d69b18a1774042f61fe891fedba96d2d630dbe066c9d9b88d18268eaad49062c76f688712a927e495f29e7b176da64676c6ef6109b2e92117ef00e1b
+netevent-2.2.2.tar.gz'


### PR DESCRIPTION
- Adds support for `image` variable to be specified to run `build()` inside of that container instead of the builder container.
- Add netevent package which makes use of new `image` variable.