### PR TITLE
Update tspascoal/get-user-teams-membership to v4

### DIFF
--- a/.github/workflows/testing-repo-commands.yml
+++ b/.github/workflows/testing-repo-commands.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Check team membership
         id: team-check
-        uses: tspascoal/get-user-teams-membership@v3
+        uses: tspascoal/get-user-teams-membership@v4
         with:
           username: ${{ github.event.comment.user.login }}
           organization: vellum-dev


### PR DESCRIPTION
This should resolve the nodejs warning in the commands workflow