### PR TITLE
Fix rM1 builds

### DIFF
--- a/packages/tilem/VELBUILD
+++ b/packages/tilem/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.codes>"
 pkgname=tilem
 pkgver=0.1.4
-pkgrel=0
+pkgrel=1
 upstream_author="timower"
 category="apps"
 pkgdesc="A TI-84+ calculator emulator for the remarkable."
@@ -34,7 +34,7 @@ prepare() {
 image() {
 	case "$CARCH" in
 	aarch64) echo "eeems/remarkable-toolchain:5.6.75-rmpp" ;;
-	armv7) echo "eeems/remarkable-toolchain:5.6.75-rm2" ;;
+	armv7) echo "eeems/remarkable-toolchain:5.6.75-rm1" ;;
 	*)
 		echo "Invalid CARCH: $CARCH"
 		exit 1
@@ -85,8 +85,7 @@ postdeinstall() {
 		rm -rf /home/root/xovi/exthome/appload/tilem
 	fi
 }
-sha512sums='
-1466a1ede8f6af015a7eacbedfa48d964e1187eeb358ddb820fd105fb6a3585c6b01ed9f54b8b7a1dbee449b7ca7bf8d72f90808a9a1b1cdbb8040167c90cc89
+sha512sums='b1dc32a1354d6f7a16603ac9ff57ae20299f4911b41684e060d448d7675b38e1d3aebbf88e5fad78f951f9577545dd2b22b5da3898e5d0a42a589827b619df39
 external.manifest.json
 a501914f2bae72334f9502506d3c3548402788dd70926b17bb4eb66d8b42031e4627d235af9a8d41396fb6a5267acad1f3fef2c87e2d7601af90e95a65f66656
 rm-toolchain.cmake'

--- a/packages/tilem/external.manifest.json
+++ b/packages/tilem/external.manifest.json
@@ -8,6 +8,7 @@
   "qtfb": true,
   "environment": {
     "LD_PRELOAD": "/home/root/shims/qtfb-shim.so",
+    "QTFB_SHIM_MODEL": "RM1",
     "QTFB_SHIM_RESPECT_APP_REFRESH_MODES": "true",
     "QTFB_SHIM_RESPECT_FULL_REFRESH_REQUESTS": "true"
   }

--- a/packages/yaft/VELBUILD
+++ b/packages/yaft/VELBUILD
@@ -1,12 +1,12 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=yaft
 pkgver=0.1.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Yet another framebuffer terminal"
 upstream_author="timower"
 category="apps"
 url="https://github.com/$upstream_author/rM2-stuff"
-arch="armv7"
+arch="armv7 aarch64"
 license="GPL-3.0"
 depends="appload"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/rM2-stuff/v$pkgver/README.md"
@@ -34,7 +34,7 @@ prepare() {
 image() {
 	case "$CARCH" in
 	aarch64) echo "eeems/remarkable-toolchain:5.6.75-rmpp" ;;
-	armv7) echo "eeems/remarkable-toolchain:5.6.75-rm2" ;;
+	armv7) echo "eeems/remarkable-toolchain:5.6.75-rm1" ;;
 	*)
 		echo "Invalid CARCH: $CARCH"
 		exit 1
@@ -46,7 +46,7 @@ build() {
 	apt-get update
 	apt-get install -y xxd
 
-	. "$(find /opt/codex -name 'environment-setup-*' -type f)"
+	. "$(find /opt/codex -name 'environment-setup-*' -type f | head -n1)"
 	export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 	cd "$srcdir/rM2-stuff-$pkgver"
 	ln -sf "$startdir"/rm-toolchain.cmake cmake/rm-toolchain.cmake
@@ -80,7 +80,7 @@ package() {
 	install -Dm755 "$startdir"/external.manifest.json \
 		"$pkgdir"/home/root/xovi/exthome/appload/yaft/external.manifest.json
 }
-sha512sums='6ab27a5be294f69830baa8ef84fc5d0e5f617067f83866f3194815e1c20c044e1a526de824b9c634a47e05bc9b267e9654840ae121fe88de743a1e06cc2fe441
+sha512sums='6796ea71840761e6eeb0ae96dfaa9d14fd46a3a0189fe3cbedde2609002bb317a19030b919ab1f38e1276fbb60531cab561b8005beb60a6d44570f6bf6b52e42
 external.manifest.json
 a501914f2bae72334f9502506d3c3548402788dd70926b17bb4eb66d8b42031e4627d235af9a8d41396fb6a5267acad1f3fef2c87e2d7601af90e95a65f66656
 rm-toolchain.cmake'

--- a/packages/yaft/external.manifest.json
+++ b/packages/yaft/external.manifest.json
@@ -5,6 +5,7 @@
   "qtfb": true,
   "environment": {
     "LD_PRELOAD": "/home/root/shims/qtfb-shim.so",
+    "QTFB_SHIM_MODEL": "RM1",
     "QTFB_SHIM_RESPECT_APP_REFRESH_MODES": "false",
     "QTFB_SHIM_RESPECT_FULL_REFRESH_REQUESTS": "false",
     "QTFB_SHIM_INPUT_PATH_NULL": "/dev/input/touchscreen0",


### PR DESCRIPTION
This makes these apps work on rM1 properly as they were encountering illegal instruction crashes. It also ensures that they continue to work on the rM2.

I've tested on everything but the pure.