### PR TITLE
Add netsurf package: port netsurf-reMarkable browser

### DIFF
--- a/packages/netsurf/Choices
+++ b/packages/netsurf/Choices
@@ -16,6 +16,7 @@ fb_face_cursive:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSerif-It
 fb_face_monospace:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSansMono.ttf
 fb_face_monospace_bold:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSansMono-Bold.ttf
 fb_face_fantasy:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSans-Oblique.ttf
+fb_face_cjk:/home/root/xovi/exthome/appload/netsurf/res/fonts/NotoSansCJKsc-Regular.otf
 
 fb_toolbar_size:60
 fb_furniture_size:40

--- a/packages/netsurf/Choices
+++ b/packages/netsurf/Choices
@@ -1,0 +1,25 @@
+homepage_url:about:welcome
+fb_download_directory:/home/root/Downloads
+
+# appload manages the app lifecycle; there is no "xochitl"/"remux" service to
+# restart here, so repurpose NetSurf's restart button to just terminate the
+# browser process (appload returns to its launcher when the app exits).
+fb_xochitl_restart_command:killall -9 netsurf
+
+scale:150
+enable_javascript:0
+
+fb_face_sans_serif:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSans.ttf
+fb_face_sans_serif_bold:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSans-Bold.ttf
+fb_face_sans_serif_italic:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSans-Oblique.ttf
+fb_face_sans_serif_italic_bold:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSans-BoldOblique.ttf
+fb_face_serif:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSansMono.ttf
+fb_face_serif_bold:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSerif-Bold.ttf
+fb_face_cursive:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSerif-Italic.ttf
+fb_face_monospace:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSansMono.ttf
+fb_face_monospace_bold:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSansMono-Bold.ttf
+fb_face_fantasy:/home/root/xovi/exthome/appload/netsurf/res/fonts/DejaVuSans-Oblique.ttf
+
+fb_toolbar_size:60
+fb_furniture_size:40
+fb_osk:1

--- a/packages/netsurf/Choices
+++ b/packages/netsurf/Choices
@@ -1,9 +1,6 @@
 homepage_url:about:welcome
 fb_download_directory:/home/root/Downloads
 
-# appload manages the app lifecycle; there is no "xochitl"/"remux" service to
-# restart here, so repurpose NetSurf's restart button to just terminate the
-# browser process (appload returns to its launcher when the app exits).
 fb_xochitl_restart_command:killall -9 netsurf
 
 scale:150

--- a/packages/netsurf/VELBUILD
+++ b/packages/netsurf/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="maicrohard <maicrohard@proton.me>"
 pkgname=netsurf
 pkgver=0.4.0
-pkgrel=2
+pkgrel=0
 pkgdesc="Lightweight web browser"
 upstream_author="MaicroNotHard"
 category="apps"
@@ -11,7 +11,7 @@ license="GPL-2.0-or-later"
 depends="appload>=0.5.3"
 options="!check !fhs !strip !tracedeps"
 
-_commit=5eef0b700d6e13097c63932eb1c6add25846798f
+_commit=36afacc3d3d921a4a6a258471fba1530bc6f6585
 _dejavuver=2.37
 
 readmeurl="https://raw.githubusercontent.com/$upstream_author/netsurf-reMarkable/$_commit/README.md"
@@ -27,9 +27,8 @@ image="ghcr.io/toltec-dev/base:v4.0"
 
 build() {
 	set -e
-	# install_dependencies.sh needs these to build FreeType (autogen.sh) and
-	# the netsurf buildsystem (the original Toltec recipe declared them as
-	# makedepends; Vellum's images don't ship them, so install at build time).
+	# Build deps for FreeType (autogen.sh) and the netsurf buildsystem; not in
+	# the base image, so install them at build time.
 	apt-get update
 	apt-get install -y automake autoconf libtool bison flex gperf libpng-dev
 	case "$CARCH" in
@@ -39,42 +38,17 @@ build() {
 		exit 1
 		;;
 	esac
-	_commit=5eef0b700d6e13097c63932eb1c6add25846798f # $_commit is not passed through to build()
+	_commit=36afacc3d3d921a4a6a258471fba1530bc6f6585 # not set in build() when image= is used
 	cd "$srcdir/netsurf-reMarkable-$_commit"
-	# The original Toltec recipe symlinked /usr/bin/which into /bin (needed on
-	# the older base:v3.2 image, which had a separate /bin). On this image
-	# /bin is itself a symlink to /usr/bin, so that command would instead
-	# create a self-referential symlink loop and break `which` entirely -
-	# it's already available at both paths, so just skip it.
-
-	# The toolchain sysroot ships prebuilt shared libs for OpenSSL 3.x
-	# (libssl.so.3/libcrypto.so.3) and curl (libcurl.so.4, linked against that
-	# same OpenSSL 3.x). install_dependencies.sh cross-builds static OpenSSL
-	# 1.1.1k and curl 7.75.0 into the same prefix (--disable-shared, so no new
-	# .so files are produced; only headers/.a libs are (re)written) - but the
-	# linker still finds and prefers the preexisting prebuilt .so's over the
-	# freshly built .a's, causing "undefined reference to
-	# SSL_get_peer_certificate/EVP_PKEY_id/EVP_PKEY_get_id@OPENSSL_3.0.0/..."
-	# (symbol names changed between OpenSSL 1.1.x and 3.x). Remove the prebuilt
-	# shared libs up front so nothing ever links against them.
+	# Remove the toolchain's prebuilt shared OpenSSL/curl/libevdev libs so the
+	# linker uses the static libs install_dependencies.sh builds instead.
 	rm -f "$SYSROOT"/usr/lib/libssl.so* "$SYSROOT"/usr/lib/libcrypto.so* \
-		"$SYSROOT"/usr/lib/libcurl.so*
+		"$SYSROOT"/usr/lib/libcurl.so* "$SYSROOT"/usr/lib/libevdev.so*
 	scripts/install_dependencies.sh
 	TARGET_WORKSPACE="$PWD"/build scripts/build.sh
-
-	# The device has no libevdev.so.2 (it's not part of the OS image or any
-	# installed package - only the toolchain sysroot ships one, prebuilt,
-	# linked against the netsurf binary at build time), so bundle it into the
-	# package alongside the binary (see package()), the same way koreader
-	# ships its own libs/ directory. package() doesn't source switch-arm.sh,
-	# so $SYSROOT isn't set there; stash the file under $srcdir here instead,
-	# where package() can reach it using only the paths it already has.
-	cp "$SYSROOT"/usr/lib/libevdev.so.2.3.0 "$srcdir"/libevdev.so.2
 }
 
 package() {
-	_commit=5eef0b700d6e13097c63932eb1c6add25846798f # $_commit is not passed through to package()
-	_dejavuver=2.37 # $_dejavuver is not passed through to package()
 	cd "$srcdir/netsurf-reMarkable-$_commit"
 	install -Dm644 LICENSE \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"
@@ -87,11 +61,6 @@ package() {
 		"$appdir"/netsurf
 	install -Dm644 "$startdir"/external.manifest.json \
 		"$appdir"/external.manifest.json
-
-	# Bundled libevdev.so.2 (see build()); external.manifest.json points
-	# LD_LIBRARY_PATH at this lib/ dir so the dynamic linker finds it.
-	install -Dm755 "$srcdir"/libevdev.so.2 \
-		"$appdir"/lib/libevdev.so.2
 
 	resdir=build/netsurf/frontends/framebuffer/res
 	install -Dm644 -t "$appdir"/res \
@@ -110,8 +79,6 @@ package() {
 	install -Dm644 "$resdir"/netsurf.png \
 		"$appdir"/icon.png
 
-	# Fetched from upstream (see source=) rather than bundled in the package
-	# repo - keeps the binary font blobs out of git history.
 	dejavudir="$srcdir/dejavu-fonts-ttf-$_dejavuver/ttf"
 	install -Dm644 -t "$appdir"/res/fonts \
 		"$dejavudir"/DejaVuSans.ttf \
@@ -130,11 +97,11 @@ postdeinstall() {
 	fi
 }
 
-sha512sums='f173b0c53e7dacfbecdefef1989def60c17cb83b56298b907b8c59c16198e634e3bbd54929b35da1daa60d63ea2e188ca139147a4c27d7361969e91f892a0213
-netsurf-reMarkable-5eef0b700d6e13097c63932eb1c6add25846798f.zip
+sha512sums='df60e4f270bba2e80e92423777424072f43d90d767a167868b6c096978aac228d7e702165ca69cf7044f423c218ce82493d979e2d9462fc92b2421aa00870818
+netsurf-reMarkable-36afacc3d3d921a4a6a258471fba1530bc6f6585.zip
 bafa39321021097432777f0825d700190c23f917d754a4504722cd8946716c22c083836294dab7f3ae7cf20af63c4d0944f3423bf4aa25dbca562d1f30e00654
 dejavu-fonts-ttf-2.37.tar.bz2
-a94da3627058da5d12ab0f57cc5b201219ab9110c963133f4280a18b1e210062d86e9422a8c9c4da0b85a84009ead21cf384649835c44fe667e228d3e91a4d4a
+34b8aaac63783679a6466b04403e71db666d4edcf6606e4c98032509719ec9ac6d513fa4a9b8b5b32aed5103352c7d2a1bc0ecc130c1a97d37dc7f0bed39cdf3
 external.manifest.json
 3a2793966be20033ab5827c631f87267a1d13bfa0276a942b66d0018e42d1386a7408f9356a03e0d52eff07180379cdd05b538faa5a84b824e0325d169b228f4
 Choices'

--- a/packages/netsurf/VELBUILD
+++ b/packages/netsurf/VELBUILD
@@ -55,15 +55,13 @@ package() {
 	echo "https://github.com/$upstream_author/netsurf-reMarkable" > \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
 
-	appdir="$pkgdir/home/root/xovi/exthome/appload/netsurf"
-
 	install -Dm755 build/netsurf/nsfb \
-		"$appdir"/netsurf
+		"$pkgdir"/home/root/xovi/exthome/appload/netsurf/netsurf
 	install -Dm644 "$startdir"/external.manifest.json \
-		"$appdir"/external.manifest.json
+		"$pkgdir"/home/root/xovi/exthome/appload/netsurf/external.manifest.json
 
 	resdir=build/netsurf/frontends/framebuffer/res
-	install -Dm644 -t "$appdir"/res \
+	install -Dm644 -t "$pkgdir"/home/root/xovi/exthome/appload/netsurf/res \
 		"$resdir"/adblock.css \
 		"$resdir"/default.css \
 		"$resdir"/quirks.css \
@@ -75,12 +73,12 @@ package() {
 		"$resdir"/welcome-netsurf.html \
 		"$resdir"/netsurf.png
 	install -Dm644 "$startdir"/Choices \
-		"$appdir"/res/Choices
+		"$pkgdir"/home/root/xovi/exthome/appload/netsurf/res/Choices
 	install -Dm644 "$resdir"/netsurf.png \
-		"$appdir"/icon.png
+		"$pkgdir"/home/root/xovi/exthome/appload/netsurf/icon.png
 
 	dejavudir="$srcdir/dejavu-fonts-ttf-$_dejavuver/ttf"
-	install -Dm644 -t "$appdir"/res/fonts \
+	install -Dm644 -t "$pkgdir"/home/root/xovi/exthome/appload/netsurf/res/fonts \
 		"$dejavudir"/DejaVuSans.ttf \
 		"$dejavudir"/DejaVuSans-Bold.ttf \
 		"$dejavudir"/DejaVuSans-Oblique.ttf \
@@ -93,7 +91,10 @@ package() {
 
 postdeinstall() {
 	if [ "$VELLUM_PURGE" = "1" ]; then
-		rm -rf /home/root/xovi/exthome/appload/netsurf
+		# NetSurf stores cookies, the URL database and saved options under
+		# ~/.netsurf (HOME=/home/root); installed files are removed by the
+		# package manager.
+		rm -rf /home/root/.netsurf
 	fi
 }
 

--- a/packages/netsurf/VELBUILD
+++ b/packages/netsurf/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="maicrohard <maicrohard@proton.me>"
 pkgname=netsurf
 pkgver=0.4.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Lightweight web browser"
 upstream_author="MaicroNotHard"
 category="apps"
@@ -11,7 +11,7 @@ license="GPL-2.0-or-later"
 depends="appload>=0.5.3"
 options="!check !fhs !strip !tracedeps"
 
-_commit=1e6d4c8b4e249ed33c80d632d9048ebb68605e38
+_commit=19074d8f53e4860f1cddec5fca0a6f16949920e0
 _dejavuver=2.37
 
 readmeurl="https://raw.githubusercontent.com/$upstream_author/netsurf-reMarkable/$_commit/README.md"
@@ -39,7 +39,7 @@ build() {
 		exit 1
 		;;
 	esac
-	_commit=1e6d4c8b4e249ed33c80d632d9048ebb68605e38 # $_commit is not passed through to build()
+	_commit=19074d8f53e4860f1cddec5fca0a6f16949920e0 # $_commit is not passed through to build()
 	cd "$srcdir/netsurf-reMarkable-$_commit"
 	# The original Toltec recipe symlinked /usr/bin/which into /bin (needed on
 	# the older base:v3.2 image, which had a separate /bin). On this image
@@ -73,7 +73,7 @@ build() {
 }
 
 package() {
-	_commit=1e6d4c8b4e249ed33c80d632d9048ebb68605e38 # $_commit is not passed through to package()
+	_commit=19074d8f53e4860f1cddec5fca0a6f16949920e0 # $_commit is not passed through to package()
 	_dejavuver=2.37 # $_dejavuver is not passed through to package()
 	cd "$srcdir/netsurf-reMarkable-$_commit"
 	install -Dm644 LICENSE \
@@ -130,8 +130,8 @@ postdeinstall() {
 	fi
 }
 
-sha512sums='db585cac462a51eb796b3f1be4a880e4a69e5e9377378faab093779ed031e3f1b93fbdfb52cc25f40603096bc11336b4177686132c4c3e6b3d6a6522b8942bb8
-netsurf-reMarkable-1e6d4c8b4e249ed33c80d632d9048ebb68605e38.zip
+sha512sums='ab774515f6509682d35ed22abe5ad5e8d156a50136ba0c39b94da3cd19edd01c19ef2d5346b4665036e8b4fb5910c4c02c8a8af04d5956d190527afcc5e24238
+netsurf-reMarkable-19074d8f53e4860f1cddec5fca0a6f16949920e0.zip
 bafa39321021097432777f0825d700190c23f917d754a4504722cd8946716c22c083836294dab7f3ae7cf20af63c4d0944f3423bf4aa25dbca562d1f30e00654
 dejavu-fonts-ttf-2.37.tar.bz2
 a94da3627058da5d12ab0f57cc5b201219ab9110c963133f4280a18b1e210062d86e9422a8c9c4da0b85a84009ead21cf384649835c44fe667e228d3e91a4d4a

--- a/packages/netsurf/VELBUILD
+++ b/packages/netsurf/VELBUILD
@@ -1,0 +1,140 @@
+maintainer="maicrohard <maicrohard@proton.me>"
+pkgname=netsurf
+pkgver=0.4.0
+pkgrel=0
+pkgdesc="Lightweight web browser"
+upstream_author="MaicroNotHard"
+category="apps"
+url="https://github.com/$upstream_author/netsurf-reMarkable"
+arch="armv7"
+license="GPL-2.0-or-later"
+depends="appload>=0.5.3"
+options="!check !fhs !strip !tracedeps"
+
+_commit=1e6d4c8b4e249ed33c80d632d9048ebb68605e38
+_dejavuver=2.37
+
+readmeurl="https://raw.githubusercontent.com/$upstream_author/netsurf-reMarkable/$_commit/README.md"
+
+source="
+netsurf-reMarkable-$_commit.zip::https://github.com/$upstream_author/netsurf-reMarkable/archive/$_commit.zip
+dejavu-fonts-ttf-$_dejavuver.tar.bz2::https://downloads.sourceforge.net/project/dejavu/dejavu/$_dejavuver/dejavu-fonts-ttf-$_dejavuver.tar.bz2
+external.manifest.json
+Choices
+"
+
+image="ghcr.io/toltec-dev/base:v4.0"
+
+build() {
+	set -e
+	# install_dependencies.sh needs these to build FreeType (autogen.sh) and
+	# the netsurf buildsystem (the original Toltec recipe declared them as
+	# makedepends; Vellum's images don't ship them, so install at build time).
+	apt-get update
+	apt-get install -y automake autoconf libtool bison flex gperf libpng-dev
+	case "$CARCH" in
+	armv7) . /opt/x-tools/switch-arm.sh ;;
+	*)
+		echo "Invalid CARCH: $CARCH"
+		exit 1
+		;;
+	esac
+	_commit=1e6d4c8b4e249ed33c80d632d9048ebb68605e38 # $_commit is not passed through to build()
+	cd "$srcdir/netsurf-reMarkable-$_commit"
+	# The original Toltec recipe symlinked /usr/bin/which into /bin (needed on
+	# the older base:v3.2 image, which had a separate /bin). On this image
+	# /bin is itself a symlink to /usr/bin, so that command would instead
+	# create a self-referential symlink loop and break `which` entirely -
+	# it's already available at both paths, so just skip it.
+
+	# The toolchain sysroot ships prebuilt shared libs for OpenSSL 3.x
+	# (libssl.so.3/libcrypto.so.3) and curl (libcurl.so.4, linked against that
+	# same OpenSSL 3.x). install_dependencies.sh cross-builds static OpenSSL
+	# 1.1.1k and curl 7.75.0 into the same prefix (--disable-shared, so no new
+	# .so files are produced; only headers/.a libs are (re)written) - but the
+	# linker still finds and prefers the preexisting prebuilt .so's over the
+	# freshly built .a's, causing "undefined reference to
+	# SSL_get_peer_certificate/EVP_PKEY_id/EVP_PKEY_get_id@OPENSSL_3.0.0/..."
+	# (symbol names changed between OpenSSL 1.1.x and 3.x). Remove the prebuilt
+	# shared libs up front so nothing ever links against them.
+	rm -f "$SYSROOT"/usr/lib/libssl.so* "$SYSROOT"/usr/lib/libcrypto.so* \
+		"$SYSROOT"/usr/lib/libcurl.so*
+	scripts/install_dependencies.sh
+	TARGET_WORKSPACE="$PWD"/build scripts/build.sh
+
+	# The device has no libevdev.so.2 (it's not part of the OS image or any
+	# installed package - only the toolchain sysroot ships one, prebuilt,
+	# linked against the netsurf binary at build time), so bundle it into the
+	# package alongside the binary (see package()), the same way koreader
+	# ships its own libs/ directory. package() doesn't source switch-arm.sh,
+	# so $SYSROOT isn't set there; stash the file under $srcdir here instead,
+	# where package() can reach it using only the paths it already has.
+	cp "$SYSROOT"/usr/lib/libevdev.so.2.3.0 "$srcdir"/libevdev.so.2
+}
+
+package() {
+	_commit=1e6d4c8b4e249ed33c80d632d9048ebb68605e38 # $_commit is not passed through to package()
+	_dejavuver=2.37 # $_dejavuver is not passed through to package()
+	cd "$srcdir/netsurf-reMarkable-$_commit"
+	install -Dm644 LICENSE \
+		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"
+	echo "https://github.com/$upstream_author/netsurf-reMarkable" > \
+		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
+
+	appdir="$pkgdir/home/root/xovi/exthome/appload/netsurf"
+
+	install -Dm755 build/netsurf/nsfb \
+		"$appdir"/netsurf
+	install -Dm644 "$startdir"/external.manifest.json \
+		"$appdir"/external.manifest.json
+
+	# Bundled libevdev.so.2 (see build()); external.manifest.json points
+	# LD_LIBRARY_PATH at this lib/ dir so the dynamic linker finds it.
+	install -Dm755 "$srcdir"/libevdev.so.2 \
+		"$appdir"/lib/libevdev.so.2
+
+	resdir=build/netsurf/frontends/framebuffer/res
+	install -Dm644 -t "$appdir"/res \
+		"$resdir"/adblock.css \
+		"$resdir"/default.css \
+		"$resdir"/quirks.css \
+		"$resdir"/internal.css \
+		"$resdir"/Messages \
+		"$resdir"/credits.html \
+		"$resdir"/licence.html \
+		"$resdir"/welcome.html \
+		"$resdir"/welcome-netsurf.html \
+		"$resdir"/netsurf.png
+	install -Dm644 "$startdir"/Choices \
+		"$appdir"/res/Choices
+	install -Dm644 "$resdir"/netsurf.png \
+		"$appdir"/icon.png
+
+	# Fetched from upstream (see source=) rather than bundled in the package
+	# repo - keeps the binary font blobs out of git history.
+	dejavudir="$srcdir/dejavu-fonts-ttf-$_dejavuver/ttf"
+	install -Dm644 -t "$appdir"/res/fonts \
+		"$dejavudir"/DejaVuSans.ttf \
+		"$dejavudir"/DejaVuSans-Bold.ttf \
+		"$dejavudir"/DejaVuSans-Oblique.ttf \
+		"$dejavudir"/DejaVuSans-BoldOblique.ttf \
+		"$dejavudir"/DejaVuSerif-Bold.ttf \
+		"$dejavudir"/DejaVuSerif-Italic.ttf \
+		"$dejavudir"/DejaVuSansMono.ttf \
+		"$dejavudir"/DejaVuSansMono-Bold.ttf
+}
+
+postdeinstall() {
+	if [ "$VELLUM_PURGE" = "1" ]; then
+		rm -rf /home/root/xovi/exthome/appload/netsurf
+	fi
+}
+
+sha512sums='db585cac462a51eb796b3f1be4a880e4a69e5e9377378faab093779ed031e3f1b93fbdfb52cc25f40603096bc11336b4177686132c4c3e6b3d6a6522b8942bb8
+netsurf-reMarkable-1e6d4c8b4e249ed33c80d632d9048ebb68605e38.zip
+bafa39321021097432777f0825d700190c23f917d754a4504722cd8946716c22c083836294dab7f3ae7cf20af63c4d0944f3423bf4aa25dbca562d1f30e00654
+dejavu-fonts-ttf-2.37.tar.bz2
+a94da3627058da5d12ab0f57cc5b201219ab9110c963133f4280a18b1e210062d86e9422a8c9c4da0b85a84009ead21cf384649835c44fe667e228d3e91a4d4a
+external.manifest.json
+3a2793966be20033ab5827c631f87267a1d13bfa0276a942b66d0018e42d1386a7408f9356a03e0d52eff07180379cdd05b538faa5a84b824e0325d169b228f4
+Choices'

--- a/packages/netsurf/VELBUILD
+++ b/packages/netsurf/VELBUILD
@@ -11,14 +11,16 @@ license="GPL-2.0-or-later"
 depends="appload>=0.5.3"
 options="!check !fhs !strip !tracedeps"
 
-_commit=94fc1d85d8ea2726066b8969bfb7594b99f20fb9
+_commit=a3cf3901953f41a6964aa3a76e3cf62ad6b0499a
 _dejavuver=2.37
+_notocjkver=2.004
 
 readmeurl="https://raw.githubusercontent.com/$upstream_author/netsurf-reMarkable/$_commit/README.md"
 
 source="
 netsurf-reMarkable-$_commit.zip::https://github.com/$upstream_author/netsurf-reMarkable/archive/$_commit.zip
 dejavu-fonts-ttf-$_dejavuver.tar.bz2::https://downloads.sourceforge.net/project/dejavu/dejavu/$_dejavuver/dejavu-fonts-ttf-$_dejavuver.tar.bz2
+noto-sans-cjk-sc-$_notocjkver.zip::https://github.com/notofonts/noto-cjk/releases/download/Sans$_notocjkver/08_NotoSansCJKsc.zip
 external.manifest.json
 Choices
 "
@@ -38,7 +40,7 @@ build() {
 		exit 1
 		;;
 	esac
-	_commit=94fc1d85d8ea2726066b8969bfb7594b99f20fb9 # not set in build() when image= is used
+	_commit=a3cf3901953f41a6964aa3a76e3cf62ad6b0499a # not set in build() when image= is used
 	cd "$srcdir/netsurf-reMarkable-$_commit"
 	# Remove the toolchain's prebuilt shared libevdev so the linker uses the
 	# static one install_dependencies.sh builds instead.
@@ -86,6 +88,10 @@ package() {
 		"$dejavudir"/DejaVuSerif-Italic.ttf \
 		"$dejavudir"/DejaVuSansMono.ttf \
 		"$dejavudir"/DejaVuSansMono-Bold.ttf
+
+	# CJK fallback font (Chinese/Japanese/Korean)
+	install -Dm644 -t "$pkgdir"/home/root/xovi/exthome/appload/netsurf/res/fonts \
+		"$srcdir"/NotoSansCJKsc-Regular.otf
 }
 
 postdeinstall() {
@@ -94,11 +100,13 @@ postdeinstall() {
 	fi
 }
 
-sha512sums='4c11302a292926bd51fc2cb0e0fdd54a04da732885260defec4f12a5a49bc90b3ea7501bc5177297332e292e4649ac0d398aebc37a4f36877ec2a22a3578b6ee
-netsurf-reMarkable-94fc1d85d8ea2726066b8969bfb7594b99f20fb9.zip
+sha512sums='6a1f3090184963b4df8db02814181c149869fff6256d99c0e702f1722e4ad40d4b51728267e53b78196670a2074f6512eea70f6800e96da32a1d03a5690e53ee
+netsurf-reMarkable-a3cf3901953f41a6964aa3a76e3cf62ad6b0499a.zip
 bafa39321021097432777f0825d700190c23f917d754a4504722cd8946716c22c083836294dab7f3ae7cf20af63c4d0944f3423bf4aa25dbca562d1f30e00654
 dejavu-fonts-ttf-2.37.tar.bz2
+d523187e27fa554d9ae3c64496235f0bd3a505a8f31f89da2762df5148be83ba1c2650fe6fa125b0214e2c1c699ee22703371b81a4d3141e522149915121fdf4
+noto-sans-cjk-sc-2.004.zip
 34b8aaac63783679a6466b04403e71db666d4edcf6606e4c98032509719ec9ac6d513fa4a9b8b5b32aed5103352c7d2a1bc0ecc130c1a97d37dc7f0bed39cdf3
 external.manifest.json
-a6f3a8963c2fb49c39dd49a11c389fe0acefb525612e3ff4b38380053ec37ec68e3b5d01638a02d11c3681347b58d08b7117f09893e6ce444620e892860e0855
+eba7f3e095216c685f1e8d55f43361026d68c9c3aeec447ea1dec4a98ae638e561119551a37a69a1e0e93b9be03dde29406006512fcfda0c663eb7413c0f286a
 Choices'

--- a/packages/netsurf/VELBUILD
+++ b/packages/netsurf/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="maicrohard <maicrohard@proton.me>"
 pkgname=netsurf
 pkgver=0.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Lightweight web browser"
 upstream_author="MaicroNotHard"
 category="apps"
@@ -11,7 +11,7 @@ license="GPL-2.0-or-later"
 depends="appload>=0.5.3"
 options="!check !fhs !strip !tracedeps"
 
-_commit=19074d8f53e4860f1cddec5fca0a6f16949920e0
+_commit=5eef0b700d6e13097c63932eb1c6add25846798f
 _dejavuver=2.37
 
 readmeurl="https://raw.githubusercontent.com/$upstream_author/netsurf-reMarkable/$_commit/README.md"
@@ -39,7 +39,7 @@ build() {
 		exit 1
 		;;
 	esac
-	_commit=19074d8f53e4860f1cddec5fca0a6f16949920e0 # $_commit is not passed through to build()
+	_commit=5eef0b700d6e13097c63932eb1c6add25846798f # $_commit is not passed through to build()
 	cd "$srcdir/netsurf-reMarkable-$_commit"
 	# The original Toltec recipe symlinked /usr/bin/which into /bin (needed on
 	# the older base:v3.2 image, which had a separate /bin). On this image
@@ -73,7 +73,7 @@ build() {
 }
 
 package() {
-	_commit=19074d8f53e4860f1cddec5fca0a6f16949920e0 # $_commit is not passed through to package()
+	_commit=5eef0b700d6e13097c63932eb1c6add25846798f # $_commit is not passed through to package()
 	_dejavuver=2.37 # $_dejavuver is not passed through to package()
 	cd "$srcdir/netsurf-reMarkable-$_commit"
 	install -Dm644 LICENSE \
@@ -130,8 +130,8 @@ postdeinstall() {
 	fi
 }
 
-sha512sums='ab774515f6509682d35ed22abe5ad5e8d156a50136ba0c39b94da3cd19edd01c19ef2d5346b4665036e8b4fb5910c4c02c8a8af04d5956d190527afcc5e24238
-netsurf-reMarkable-19074d8f53e4860f1cddec5fca0a6f16949920e0.zip
+sha512sums='f173b0c53e7dacfbecdefef1989def60c17cb83b56298b907b8c59c16198e634e3bbd54929b35da1daa60d63ea2e188ca139147a4c27d7361969e91f892a0213
+netsurf-reMarkable-5eef0b700d6e13097c63932eb1c6add25846798f.zip
 bafa39321021097432777f0825d700190c23f917d754a4504722cd8946716c22c083836294dab7f3ae7cf20af63c4d0944f3423bf4aa25dbca562d1f30e00654
 dejavu-fonts-ttf-2.37.tar.bz2
 a94da3627058da5d12ab0f57cc5b201219ab9110c963133f4280a18b1e210062d86e9422a8c9c4da0b85a84009ead21cf384649835c44fe667e228d3e91a4d4a

--- a/packages/netsurf/VELBUILD
+++ b/packages/netsurf/VELBUILD
@@ -11,7 +11,7 @@ license="GPL-2.0-or-later"
 depends="appload>=0.5.3"
 options="!check !fhs !strip !tracedeps"
 
-_commit=a3cf3901953f41a6964aa3a76e3cf62ad6b0499a
+_commit=0ebeaa879e57c729bbf3d93509b7e718f621c5d0
 _dejavuver=2.37
 _notocjkver=2.004
 
@@ -40,7 +40,7 @@ build() {
 		exit 1
 		;;
 	esac
-	_commit=a3cf3901953f41a6964aa3a76e3cf62ad6b0499a # not set in build() when image= is used
+	_commit=0ebeaa879e57c729bbf3d93509b7e718f621c5d0 # not set in build() when image= is used
 	cd "$srcdir/netsurf-reMarkable-$_commit"
 	# Remove the toolchain's prebuilt shared libevdev so the linker uses the
 	# static one install_dependencies.sh builds instead.
@@ -96,12 +96,14 @@ package() {
 
 postdeinstall() {
 	if [ "$VELLUM_PURGE" = "1" ]; then
+		# Remove runtime data and the app dir.
 		rm -rf /home/root/.netsurf
+		rm -rf /home/root/xovi/exthome/appload/netsurf
 	fi
 }
 
-sha512sums='6a1f3090184963b4df8db02814181c149869fff6256d99c0e702f1722e4ad40d4b51728267e53b78196670a2074f6512eea70f6800e96da32a1d03a5690e53ee
-netsurf-reMarkable-a3cf3901953f41a6964aa3a76e3cf62ad6b0499a.zip
+sha512sums='25eaef2e499548c383def59967eb7eb710c10a24f7b1723224ae94e50a260eda5ffd32e9f41f6dabd9524679da7f7b065fefd511f40f7b251150ef5ed5f859f8
+netsurf-reMarkable-0ebeaa879e57c729bbf3d93509b7e718f621c5d0.zip
 bafa39321021097432777f0825d700190c23f917d754a4504722cd8946716c22c083836294dab7f3ae7cf20af63c4d0944f3423bf4aa25dbca562d1f30e00654
 dejavu-fonts-ttf-2.37.tar.bz2
 d523187e27fa554d9ae3c64496235f0bd3a505a8f31f89da2762df5148be83ba1c2650fe6fa125b0214e2c1c699ee22703371b81a4d3141e522149915121fdf4

--- a/packages/netsurf/VELBUILD
+++ b/packages/netsurf/VELBUILD
@@ -11,7 +11,7 @@ license="GPL-2.0-or-later"
 depends="appload>=0.5.3"
 options="!check !fhs !strip !tracedeps"
 
-_commit=36afacc3d3d921a4a6a258471fba1530bc6f6585
+_commit=94fc1d85d8ea2726066b8969bfb7594b99f20fb9
 _dejavuver=2.37
 
 readmeurl="https://raw.githubusercontent.com/$upstream_author/netsurf-reMarkable/$_commit/README.md"
@@ -38,12 +38,11 @@ build() {
 		exit 1
 		;;
 	esac
-	_commit=36afacc3d3d921a4a6a258471fba1530bc6f6585 # not set in build() when image= is used
+	_commit=94fc1d85d8ea2726066b8969bfb7594b99f20fb9 # not set in build() when image= is used
 	cd "$srcdir/netsurf-reMarkable-$_commit"
-	# Remove the toolchain's prebuilt shared OpenSSL/curl/libevdev libs so the
-	# linker uses the static libs install_dependencies.sh builds instead.
-	rm -f "$SYSROOT"/usr/lib/libssl.so* "$SYSROOT"/usr/lib/libcrypto.so* \
-		"$SYSROOT"/usr/lib/libcurl.so* "$SYSROOT"/usr/lib/libevdev.so*
+	# Remove the toolchain's prebuilt shared libevdev so the linker uses the
+	# static one install_dependencies.sh builds instead.
+	rm -f "$SYSROOT"/usr/lib/libevdev.so*
 	scripts/install_dependencies.sh
 	TARGET_WORKSPACE="$PWD"/build scripts/build.sh
 }
@@ -91,18 +90,15 @@ package() {
 
 postdeinstall() {
 	if [ "$VELLUM_PURGE" = "1" ]; then
-		# NetSurf stores cookies, the URL database and saved options under
-		# ~/.netsurf (HOME=/home/root); installed files are removed by the
-		# package manager.
 		rm -rf /home/root/.netsurf
 	fi
 }
 
-sha512sums='df60e4f270bba2e80e92423777424072f43d90d767a167868b6c096978aac228d7e702165ca69cf7044f423c218ce82493d979e2d9462fc92b2421aa00870818
-netsurf-reMarkable-36afacc3d3d921a4a6a258471fba1530bc6f6585.zip
+sha512sums='4c11302a292926bd51fc2cb0e0fdd54a04da732885260defec4f12a5a49bc90b3ea7501bc5177297332e292e4649ac0d398aebc37a4f36877ec2a22a3578b6ee
+netsurf-reMarkable-94fc1d85d8ea2726066b8969bfb7594b99f20fb9.zip
 bafa39321021097432777f0825d700190c23f917d754a4504722cd8946716c22c083836294dab7f3ae7cf20af63c4d0944f3423bf4aa25dbca562d1f30e00654
 dejavu-fonts-ttf-2.37.tar.bz2
 34b8aaac63783679a6466b04403e71db666d4edcf6606e4c98032509719ec9ac6d513fa4a9b8b5b32aed5103352c7d2a1bc0ecc130c1a97d37dc7f0bed39cdf3
 external.manifest.json
-3a2793966be20033ab5827c631f87267a1d13bfa0276a942b66d0018e42d1386a7408f9356a03e0d52eff07180379cdd05b538faa5a84b824e0325d169b228f4
+a6f3a8963c2fb49c39dd49a11c389fe0acefb525612e3ff4b38380053ec37ec68e3b5d01638a02d11c3681347b58d08b7117f09893e6ce444620e892860e0855
 Choices'

--- a/packages/netsurf/external.manifest.json
+++ b/packages/netsurf/external.manifest.json
@@ -5,12 +5,10 @@
   "qtfb": true,
   "environment": {
     "LD_PRELOAD": "/home/root/shims/qtfb-shim.so",
-    "QTFB_SHIM_MODEL": "RM2",
     "QTFB_SHIM_RESPECT_APP_REFRESH_MODES": "true",
     "QTFB_SHIM_RESPECT_FULL_REFRESH_REQUESTS": "true",
     "QTFB_SHIM_INPUT_MODE": "NATIVE",
     "HOME": "/home/root",
-    "NETSURFRES": "/home/root/xovi/exthome/appload/netsurf/res",
-    "LD_LIBRARY_PATH": "/home/root/xovi/exthome/appload/netsurf/lib"
+    "NETSURFRES": "/home/root/xovi/exthome/appload/netsurf/res"
   }
 }

--- a/packages/netsurf/external.manifest.json
+++ b/packages/netsurf/external.manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "NetSurf",
+  "application": "netsurf",
+  "aspectRatio": "original",
+  "qtfb": true,
+  "environment": {
+    "LD_PRELOAD": "/home/root/shims/qtfb-shim.so",
+    "QTFB_SHIM_MODEL": "RM2",
+    "QTFB_SHIM_RESPECT_APP_REFRESH_MODES": "true",
+    "QTFB_SHIM_RESPECT_FULL_REFRESH_REQUESTS": "true",
+    "QTFB_SHIM_INPUT_MODE": "NATIVE",
+    "HOME": "/home/root",
+    "NETSURFRES": "/home/root/xovi/exthome/appload/netsurf/res",
+    "LD_LIBRARY_PATH": "/home/root/xovi/exthome/appload/netsurf/lib"
+  }
+}


### PR DESCRIPTION
## Summary
- Ports MaicroNotHard's [netsurf-reMarkable](https://github.com/MaicroNotHard/netsurf-reMarkable) framebuffer browser
  (a fork of alex0809's [original Toltec package](https://github.com/alex0809/netsurf-reMarkable), archived) to a Vellum VELBUILD recipe, running through
  appload + qtfb-shim like tilem/yaft
- Bundles `libevdev.so.2` (not present on-device or in any Vellum package) and fetches DejaVu
  fonts + the netsurf source from upstream at build time, keeping binary blobs out of git history
- `QTFB_SHIM_MODEL` is set to RM2 -- netsurf-reMarkable does its own rM1/rM2 detection and
  X-axis inversion for RM1, so telling the shim to lie about the model would conflict with the
  app's own correct-for-RM2 logic

## Test plan
- [x] Built and ran on a reMarkable 2: basic browsing, on-screen keyboard, and touch input work.
- [ ] Not tested on rM1 and RMPP*: no hardware available. I would appreciate testing/feedback others.

---
Co-developed with Claude Code (Anthropic).