### PR TITLE
Fix starting some systemd services on the rMPP

### DIFF
--- a/packages/rmpp-fixes/VELBUILD
+++ b/packages/rmpp-fixes/VELBUILD
@@ -1,0 +1,72 @@
+maintainer="Nathaniel van Diepen <eeems@eeems.email>"
+pkgname=rmpp-fixes
+pkgver=0.1
+pkgrel=0
+pkgdesc="Fix systemd service startup issues on the rMPP"
+upstream_author="vellum-dev"
+category="fixes"
+url="https://vellum.delivery/"
+arch="aarch64"
+license="MIT"
+depends="rmpp remarkable-os>=3.27.1.0"
+options="!check !fhs !strip !tracedeps"
+source="
+rmpp-fixes.conf
+"
+
+package() {
+	install -Dm644 "$srcdir"/rmpp-fixes.conf \
+		"$pkgdir"/home/root/.vellum/share/rmpp-fixes/rmpp-fixes.conf
+}
+postinstall() {
+	if [ "$SKIP_SYSTEMD_HANDLING" != "1" ]; then
+		/home/root/.vellum/bin/mount-rw
+		cp /home/root/.vellum/share/rmpp-fixes/rmpp-fixes.conf \
+			/etc/systemd/system/systemd-logind.service.d/override.conf
+		cp /home/root/.vellum/share/rmpp-fixes/rmpp-fixes.conf \
+			/etc/systemd/system/systemd-resolved.service.d/override.conf
+		cp /home/root/.vellum/share/rmpp-fixes/rmpp-fixes.conf \
+			/etc/systemd/system/chronyd.service.d/override.conf
+		systemctl daemon-reload
+		systemctl reset-failed \
+			systemd-logind \
+			systemd-resolved \
+			chronyd
+		systemctl restart \
+			systemd-logind \
+			systemd-resolved \
+			chronyd
+		/home/root/.vellum/bin/mount-restore
+	fi
+}
+postupgrade() {
+	postinstall
+}
+postosupgrade() {
+	if [ "$SKIP_SYSTEMD_HANDLING" != "1" ]; then
+		cp /home/root/.vellum/share/rmpp-fixes/rmpp-fixes.conf \
+			/etc/systemd/system/systemd-logind.service.d/override.conf
+		cp /home/root/.vellum/share/rmpp-fixes/rmpp-fixes.conf \
+			/etc/systemd/system/systemd-resolved.service.d/override.conf
+		cp /home/root/.vellum/share/rmpp-fixes/rmpp-fixes.conf \
+			/etc/systemd/system/chronyd.service.d/override.conf
+		systemctl daemon-reload
+		systemctl reset-failed \
+			systemd-logind \
+			systemd-resolved \
+			chronyd
+		systemctl restart \
+			systemd-logind \
+			systemd-resolved \
+			chronyd
+	fi
+}
+predeinstall() {
+	rm -f \
+		/etc/systemd/system/systemd-logind.service.d/override.conf \
+		/etc/systemd/system/systemd-resolved.service.d/override.conf \
+		/etc/systemd/system/chronyd.service.d/override.conf
+	systemctl daemon-reload
+}
+sha512sums='b8131a0cfab85a6d57853f2cab9f0c454084142bef5967ee0cbb4dd2845abe71c040a3ac2b4c81724a537fef3443e3fe12d74dd99f88eb19c756602aa451ef32
+rmpp-fixes.conf'

--- a/packages/rmpp-fixes/rmpp-fixes.conf
+++ b/packages/rmpp-fixes/rmpp-fixes.conf
@@ -1,0 +1,2 @@
+[Service]
+PrivateTmp=no


### PR DESCRIPTION
Resolves startup issues for the following services:
- systemd-logind
- systemd-resolved
- chronyd

@rmitchellscott Is specifying a depends on a specific device enough to make reManager properly display that it's only for the rMPP? Otherwise we can switch to the !rm1/!rm2/etc style. I've also limited the OS version since I don't know if it's an issue on older versions.