### PR TITLE
hide-title-quick-browse: new package

### DIFF
--- a/packages/hide-title-quick-browse/VELBUILD
+++ b/packages/hide-title-quick-browse/VELBUILD
@@ -8,7 +8,7 @@ pkgdesc="Hides the document-title bar shown while the quick-browse page-slider i
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
+depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
 _commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#hidetitlequickbrowse"
 donateurl="https://buymeacoffee.com/afaraci"

--- a/packages/hide-title-quick-browse/VELBUILD
+++ b/packages/hide-title-quick-browse/VELBUILD
@@ -1,0 +1,33 @@
+maintainer="Alessio Faraci <contact@afaraci.com>"
+pkgname=hide-title-quick-browse
+pkgver=1.0.0
+pkgrel=0
+upstream_author="alefaraci"
+category="ui"
+pkgdesc="Hides the document-title bar shown while the quick-browse page-slider is up"
+url="https://github.com/alefaraci/xovi-qmd-extensions"
+arch="noarch"
+license="GPL-3.0-only"
+depends="qt-resource-rebuilder !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
+_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#hidetitlequickbrowse"
+donateurl="https://buymeacoffee.com/afaraci"
+source="
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/hideTitleQuickBrowse.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
+"
+options="!check !fhs"
+
+package() {
+	install -Dm644 "$srcdir"/hideTitleQuickBrowse.qmd \
+		"$pkgdir"/home/root/xovi/exthome/qt-resource-rebuilder/hideTitleQuickBrowse.qmd
+
+	install -Dm644 "$srcdir"/LICENSE \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/LICENSE
+	echo "$url" > \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
+}
+sha512sums="
+47dfc6fbb06b375855a95b9cb6962d4fb77ea4bc4c58122516a29f7c5c42eec7681afc8677fa30c143e83cc3dc3135acd5332594e7754989b013d233ecd87028  hideTitleQuickBrowse.qmd
+6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
+"


### PR DESCRIPTION
Adds `hide-title-quick-browse` — a XOVI / qt-resource-rebuilder QML extension that hides the document-title bar shown at the top of the screen while the quick-browse page-slider is up (one-finger swipe up from the bottom edge).

- **Upstream:** https://github.com/alefaraci/xovi-qmd-extensions (pinned by `_commit`)
- **License:** GPL-3.0-only · **arch:** noarch
- **Depends:** `qt-resource-rebuilder`
- **Device/OS:** Paper Pure only (`!rm1 !rm2 !rmpp !rmppm`), `remarkable-os>=3.27 <3.28` — the only device I can test; happy to widen as other devices are confirmed.

<img width="350" alt="title" src="https://github.com/user-attachments/assets/0dc7c614-4f96-4750-989c-16ae071b6065" />

