### PR TITLE
dock-buttons: new package

### DIFF
--- a/packages/dock-buttons/VELBUILD
+++ b/packages/dock-buttons/VELBUILD
@@ -8,7 +8,7 @@ pkgdesc="Adds My Files / Favorites / Tags / Trash shortcut buttons to the homepa
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder !fav-tag-button !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
+depends="qt-resource-rebuilder !fav-tag-button remarkable-os>=3.27 remarkable-os<3.28"
 _commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#dockbuttons"
 donateurl="https://buymeacoffee.com/afaraci"

--- a/packages/dock-buttons/VELBUILD
+++ b/packages/dock-buttons/VELBUILD
@@ -1,0 +1,33 @@
+maintainer="Alessio Faraci <contact@afaraci.com>"
+pkgname=dock-buttons
+pkgver=1.0.0
+pkgrel=0
+upstream_author="alefaraci"
+category="ui"
+pkgdesc="Adds My Files / Favorites / Tags / Trash shortcut buttons to the homepage dock"
+url="https://github.com/alefaraci/xovi-qmd-extensions"
+arch="noarch"
+license="GPL-3.0-only"
+depends="qt-resource-rebuilder !fav-tag-button !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
+_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#dockbuttons"
+donateurl="https://buymeacoffee.com/afaraci"
+source="
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/dockButtons.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
+"
+options="!check !fhs"
+
+package() {
+	install -Dm644 "$srcdir"/dockButtons.qmd \
+		"$pkgdir"/home/root/xovi/exthome/qt-resource-rebuilder/dockButtons.qmd
+
+	install -Dm644 "$srcdir"/LICENSE \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/LICENSE
+	echo "$url" > \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
+}
+sha512sums="
+08e44df7cdf3d2acd2daa61cdb3b57c23aa39765ea3679e5f522ca177bc0e3df49d2aead6fe1998e48250ecad3176a5dc915235a81ee52ca9e50ca41792fe794  dockButtons.qmd
+6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
+"


### PR DESCRIPTION
Adds `dock-buttons` — a XOVI / qt-resource-rebuilder QML extension that adds four shortcut buttons to the homepage dock: My Files, Favorites, Tags and Trash, each jumping the file browser straight to that view in one tap.

- **Upstream:** https://github.com/alefaraci/xovi-qmd-extensions (pinned by `_commit`)
- **License:** GPL-3.0-only · **arch:** noarch
- **Depends:** `qt-resource-rebuilder`
- **Conflicts:** `fav-tag-button` (this extends the same dock-button row).
- **Attribution:** extends FouzR's `favTagButton.qmd` (GPL-3.0) — Favorites/Tags buttons are FouzR's; I added the My Files + Trash buttons, signals and handlers.
- **Device/OS:** Paper Pure only (`!rm1 !rm2 !rmpp !rmppm`), `remarkable-os>=3.27 <3.28` — the only device I can test; happy to widen as other devices are confirmed.

<img width="442" height="85" alt="Dock" src="https://github.com/user-attachments/assets/ae79179c-6515-4e7d-891e-9ffad4a98cbc" />
