### PR TITLE
hide-back-to-page-bar: new package

### DIFF
--- a/packages/hide-back-to-page-bar/VELBUILD
+++ b/packages/hide-back-to-page-bar/VELBUILD
@@ -8,7 +8,7 @@ pkgdesc="Hides the native Back-to-page-N bar shown after following a PDF hyperli
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder !hide-hyperlink-back-button !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
+depends="qt-resource-rebuilder !hide-hyperlink-back-button remarkable-os>=3.27 remarkable-os<3.28"
 _commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#hidebacktopagebar"
 donateurl="https://buymeacoffee.com/afaraci"

--- a/packages/hide-back-to-page-bar/VELBUILD
+++ b/packages/hide-back-to-page-bar/VELBUILD
@@ -1,0 +1,33 @@
+maintainer="Alessio Faraci <contact@afaraci.com>"
+pkgname=hide-back-to-page-bar
+pkgver=1.0.0
+pkgrel=0
+upstream_author="alefaraci"
+category="ui"
+pkgdesc="Hides the native Back-to-page-N bar shown after following a PDF hyperlink"
+url="https://github.com/alefaraci/xovi-qmd-extensions"
+arch="noarch"
+license="GPL-3.0-only"
+depends="qt-resource-rebuilder !hide-hyperlink-back-button !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
+_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#hidebacktopagebar"
+donateurl="https://buymeacoffee.com/afaraci"
+source="
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/hideBackToPageBar.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
+"
+options="!check !fhs"
+
+package() {
+	install -Dm644 "$srcdir"/hideBackToPageBar.qmd \
+		"$pkgdir"/home/root/xovi/exthome/qt-resource-rebuilder/hideBackToPageBar.qmd
+
+	install -Dm644 "$srcdir"/LICENSE \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/LICENSE
+	echo "$url" > \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
+}
+sha512sums="
+ef7774506438886b5aca21669b805e347e19c642600aed0e1d35b4560e4ad98af517638880070c1cbd4419ac608097e89c6a58b033f6f2db4f73a7f44be22215  hideBackToPageBar.qmd
+6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
+"


### PR DESCRIPTION
Adds `hide-back-to-page-bar` — a XOVI / qt-resource-rebuilder QML extension that hides the native "Back to page N" + Page numbering bar xochitl pops up after you follow a PDF hyperlink.

- **Upstream:** https://github.com/alefaraci/xovi-qmd-extensions (pinned by `_commit`)
- **License:** GPL-3.0-only · **arch:** noarch
- **Depends:** `qt-resource-rebuilder`
- **Conflicts:** `hide-hyperlink-back-button` (this extends hiding to the entire bar).
- **Device/OS:** Paper Pure only (`!rm1 !rm2 !rmpp !rmppm`), `remarkable-os>=3.27 <3.28` — the only device I can test; happy to widen as other devices are confirmed.

<img width="680" height="263" alt="backbar" src="https://github.com/user-attachments/assets/60714112-6475-4554-af11-8b96d409aca0" />
