### PR TITLE
gestik: new package

### DIFF
--- a/packages/gestik/VELBUILD
+++ b/packages/gestik/VELBUILD
@@ -8,7 +8,7 @@ pkgdesc="Configurable multi-finger gestures for tool switching and page/ToC navi
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder !gestures-fouzr !gestures-ingatellent !four-finger-change-filter !three-finger-swipe-to-reset-view !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
+depends="qt-resource-rebuilder !gestures-fouzr !gestures-ingatellent !four-finger-change-filter !three-finger-swipe-to-reset-view remarkable-os>=3.27 remarkable-os<3.28"
 _commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#gestik"
 donateurl="https://buymeacoffee.com/afaraci"

--- a/packages/gestik/VELBUILD
+++ b/packages/gestik/VELBUILD
@@ -1,0 +1,33 @@
+maintainer="Alessio Faraci <contact@afaraci.com>"
+pkgname=gestik
+pkgver=1.0.0
+pkgrel=0
+upstream_author="alefaraci"
+category="ui"
+pkgdesc="Configurable multi-finger gestures for tool switching and page/ToC navigation"
+url="https://github.com/alefaraci/xovi-qmd-extensions"
+arch="noarch"
+license="GPL-3.0-only"
+depends="qt-resource-rebuilder !gestures-fouzr !gestures-ingatellent !four-finger-change-filter !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
+_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#gestik"
+donateurl="https://buymeacoffee.com/afaraci"
+source="
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/gestik.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
+"
+options="!check !fhs"
+
+package() {
+	install -Dm644 "$srcdir"/gestik.qmd \
+		"$pkgdir"/home/root/xovi/exthome/qt-resource-rebuilder/gestik.qmd
+
+	install -Dm644 "$srcdir"/LICENSE \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/LICENSE
+	echo "$url" > \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
+}
+sha512sums="
+2a5bacdf77fcf442706a312a68bd044c0743e599da77df2867db7b6f0a8ed963ea5d0f5c2c60c4a934dc99149dfaea07e8181bd3acaa9b3c372c0768a87143e0  gestik.qmd
+6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
+"

--- a/packages/gestik/VELBUILD
+++ b/packages/gestik/VELBUILD
@@ -8,7 +8,7 @@ pkgdesc="Configurable multi-finger gestures for tool switching and page/ToC navi
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder !gestures-fouzr !gestures-ingatellent !four-finger-change-filter !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
+depends="qt-resource-rebuilder !gestures-fouzr !gestures-ingatellent !four-finger-change-filter !three-finger-swipe-to-reset-view !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
 _commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#gestik"
 donateurl="https://buymeacoffee.com/afaraci"


### PR DESCRIPTION
Adds `gestik` — a XOVI / qt-resource-rebuilder QML extension: a configurable multi-finger gesture bundle. 3- and 4-finger swipes switch pen/tool & thickness presets, a 4-finger tap toggles lasso/selection, and 5-finger swipes open Page Overview / Table of Contents. Configured from a dedicated **Settings ▸ Gestik** page.

- **Upstream:** https://github.com/alefaraci/xovi-qmd-extensions (pinned by `_commit`)
- **License:** GPL-3.0-only · **arch:** noarch
- **Depends:** `qt-resource-rebuilder`
- **Conflicts:** other gesture mods that hook the same handlers — `gestures-fouzr`, `gestures-ingatellent`, `four-finger-change-filter`.
- **Attribution:** the Settings-page injection is modelled on rmitchellscott's rm-stylus-remapper (GPL-3.0).
- **Device/OS:** Paper Pure only (`!rm1 !rm2 !rmpp !rmppm`), `remarkable-os>=3.27 <3.28` — the only device I can test; happy to widen as other devices are confirmed.


| <img width="350" alt="Gestik cheat sheet 1" src="https://github.com/user-attachments/assets/6d720fdf-bd82-43bf-99a8-09b11b5c201c" /> |  <img width="350" alt="Gestik cheat sheet 2" src="https://github.com/user-attachments/assets/218d7598-ad70-450b-bf97-e44474eed33a" /> |
|:---:|:---:|


|<img width="450" alt="Gestik settings" src="https://github.com/user-attachments/assets/61a29634-73e8-4f8f-80b5-8738aa326ae5" />|
|:--:|

