### PR TITLE
bettertoc-collapse-all: new package

### DIFF
--- a/packages/bettertoc-collapse-all/VELBUILD
+++ b/packages/bettertoc-collapse-all/VELBUILD
@@ -8,7 +8,7 @@ pkgdesc="Adds a collapse-all / expand-all button to the Table-of-Contents header
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder bettertoc bettertoc-collapse !rmhacks !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
+depends="qt-resource-rebuilder bettertoc bettertoc-collapse !rmhacks remarkable-os>=3.27 remarkable-os<3.28"
 _commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#bettertoccollapseall"
 donateurl="https://buymeacoffee.com/afaraci"

--- a/packages/bettertoc-collapse-all/VELBUILD
+++ b/packages/bettertoc-collapse-all/VELBUILD
@@ -1,0 +1,33 @@
+maintainer="Alessio Faraci <contact@afaraci.com>"
+pkgname=bettertoc-collapse-all
+pkgver=1.0.0
+pkgrel=0
+upstream_author="alefaraci"
+category="ui"
+pkgdesc="Adds a collapse-all / expand-all button to the Table-of-Contents header"
+url="https://github.com/alefaraci/xovi-qmd-extensions"
+arch="noarch"
+license="GPL-3.0-only"
+depends="qt-resource-rebuilder bettertoc bettertoc-collapse !rmhacks !rm1 !rm2 !rmpp !rmppm remarkable-os>=3.27 remarkable-os<3.28"
+_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#bettertoccollapseall"
+donateurl="https://buymeacoffee.com/afaraci"
+source="
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/betterTocCollapseAll.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
+"
+options="!check !fhs"
+
+package() {
+	install -Dm644 "$srcdir"/betterTocCollapseAll.qmd \
+		"$pkgdir"/home/root/xovi/exthome/qt-resource-rebuilder/betterTocCollapseAll.qmd
+
+	install -Dm644 "$srcdir"/LICENSE \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/LICENSE
+	echo "$url" > \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
+}
+sha512sums="
+15bb643bb0ac914808de547a7cee8b00fe0f48a46416b796230685e6495ae91f8e1912daf33c4f51bba16a97ea63723442b50c48caf3bfb7e3e3efa0a1e6d05a  betterTocCollapseAll.qmd
+6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
+"


### PR DESCRIPTION
Adds `bettertoc-collapse-all` — a XOVI / qt-resource-rebuilder QML extension that adds a collapse-all / expand-all button to the Table-of-Contents header bar. The button is hidden for documents with no nested entries.

- **Upstream:** https://github.com/alefaraci/xovi-qmd-extensions (pinned by `_commit`)
- **License:** GPL-3.0-only · **arch:** noarch
- **Depends:** `qt-resource-rebuilder`, `bettertoc`, `bettertoc-collapse`
- **Note:** a companion to `bettertoc` + `bettertoc-collapse` — it builds on their ToC view and per-entry collapse state.
- **Device/OS:** Paper Pure only (`!rm1 !rm2 !rmpp !rmppm`), `remarkable-os>=3.27 <3.28` — the only device I can test; happy to widen as other devices are confirmed.

<img width="416" height="62" alt="ToC button" src="https://github.com/user-attachments/assets/3b6c7f2d-23d8-41f6-9353-1a78bfd1d419" />

<img width="416" alt="ToC" src="https://github.com/user-attachments/assets/ce065b98-18eb-4bb9-9353-7eb8f2e86df1" />
