### PR TITLE
Update packages for RemarkableOS 3.27; add battery-percentage

### DIFF
--- a/packages/battery-percentage/VELBUILD
+++ b/packages/battery-percentage/VELBUILD
@@ -1,11 +1,11 @@
 maintainer="Mitchell Scott <mitchell@scottlabs.io>"
 status="maintained"
-pkgname=uncompress-dock
+pkgname=battery-percentage
 pkgver=1.0.0
-pkgrel=3
+pkgrel=1
 upstream_author="NohamR"
 category="ui"
-pkgdesc="Replaces the More menu in the document dock with dedicated notebook, folder, and quick sheet buttons."
+pkgdesc="Shows the battery percentage next to the battery icon in the main view header."
 url="https://github.com/NohamR/xovi-qmd-extensions"
 arch="noarch"
 license="MIT"
@@ -13,14 +13,14 @@ depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
 _commit="86e43a4d8d26c49abcc81f149245ff1f52961124"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md"
 source="
-uncompressDock.qmd::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27.3.0/uncompressDock.qmd
+batteryPercentage.qmd::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27.3.0/batteryPercentage.qmd
 LICENSE::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="!check !fhs"
 
 package() {
-	install -Dm644 "$srcdir/uncompressDock.qmd" \
-		"$pkgdir/home/root/xovi/exthome/qt-resource-rebuilder/uncompressDock.qmd"
+	install -Dm644 "$srcdir/batteryPercentage.qmd" \
+		"$pkgdir/home/root/xovi/exthome/qt-resource-rebuilder/batteryPercentage.qmd"
 
 	install -Dm644 "$srcdir/LICENSE" \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"
@@ -28,6 +28,6 @@ package() {
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
 }
 sha512sums="
-745dab2e884d1efb4cd3b757433951736f17abcd72b2b493e2c661e48e058fefe91d6d7c4f1085b5897bac8d957267c3b82024cdf5be377992688c2039c16780  uncompressDock.qmd
+572481c9cd779abe092b14034fcdb04cfba537fb21e83f51dd27084d63493602a5051894f86ffddc1b59b361ef5a6af7ec44c991f26fdec53bf916f8942e5b5c  batteryPercentage.qmd
 f0ca1d1c12e36cf1a6ea8a55e96186b2157d168bebf838704f18b9eaea043c98993ea25a8e99e2b704065534dd7f9a5e3a563b856a57d97eef40c057b2df4caa  LICENSE
 "

--- a/packages/battery-percentage/VELBUILD
+++ b/packages/battery-percentage/VELBUILD
@@ -28,6 +28,6 @@ package() {
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
 }
 sha512sums="
-572481c9cd779abe092b14034fcdb04cfba537fb21e83f51dd27084d63493602a5051894f86ffddc1b59b361ef5a6af7ec44c991f26fdec53bf916f8942e5b5c  batteryPercentage.qmd
+572481c9cd779abe092b14034fcdb04cfba537fb21e83f51dd27084d63493602a5051894f86ffddc1b59b361ef5a6af7ec44c991f26cdec53bf916f8942e5b5c  batteryPercentage.qmd
 f0ca1d1c12e36cf1a6ea8a55e96186b2157d168bebf838704f18b9eaea043c98993ea25a8e99e2b704065534dd7f9a5e3a563b856a57d97eef40c057b2df4caa  LICENSE
 "

--- a/packages/battery-percentage/VELBUILD
+++ b/packages/battery-percentage/VELBUILD
@@ -1,8 +1,8 @@
-maintainer="Mitchell Scott <mitchell@scottlabs.io>"
+maintainer="NohamR <noham@noh.am>"
 status="maintained"
 pkgname=battery-percentage
 pkgver=1.0.0
-pkgrel=1
+pkgrel=0
 upstream_author="NohamR"
 category="ui"
 pkgdesc="Shows the battery percentage next to the battery icon in the main view header."

--- a/packages/convert-to-text-remover/VELBUILD
+++ b/packages/convert-to-text-remover/VELBUILD
@@ -1,19 +1,19 @@
 maintainer="Mitchell Scott <mitchell@scottlabs.io>"
-status="unmaintained"
+status="maintained"
 pkgname=convert-to-text-remover
 pkgver=1.0.0
-pkgrel=2
+pkgrel=3
 upstream_author="NohamR"
 category="ui"
 pkgdesc="Removes the Convert to text option from selection menus and the toolbar."
 url="https://github.com/NohamR/xovi-qmd-extensions"
 arch="noarch"
 license="MIT"
-depends="qt-resource-rebuilder remarkable-os>=3.23 remarkable-os<3.24"
-_commit="17898d11afc96767842507cc2a9606a974ae5ec5"
+depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
+_commit="86e43a4d8d26c49abcc81f149245ff1f52961124"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md"
 source="
-convertToText_remover.qmd::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.23.0.64/convertToText_remover.qmd
+convertToText_remover.qmd::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27.3.0/convertToText_remover.qmd
 LICENSE::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="!check !fhs"
@@ -28,6 +28,6 @@ package() {
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
 }
 sha512sums="
-892a77e03859a609617fea9483cdb657ae66b382aca4cebb1835cafdcb666b0735de9415ce9368f1a0c0269d58b6f7d54f5abec636fd77d604e0ebb3dd316b3d  convertToText_remover.qmd
+363f8ddce988f6f4b8e9d40bed70c5a74f4315d37a2ebd33d233a6c9f8ff44d94955dc20925d292299338cf3681b8734dec120382f34b5200f656481e5b4fc42  convertToText_remover.qmd
 f0ca1d1c12e36cf1a6ea8a55e96186b2157d168bebf838704f18b9eaea043c98993ea25a8e99e2b704065534dd7f9a5e3a563b856a57d97eef40c057b2df4caa  LICENSE
 "

--- a/packages/convert-to-text-remover/VELBUILD
+++ b/packages/convert-to-text-remover/VELBUILD
@@ -1,8 +1,8 @@
-maintainer="Mitchell Scott <mitchell@scottlabs.io>"
+maintainer="NohamR <noham@noh.am>"
 status="maintained"
 pkgname=convert-to-text-remover
-pkgver=1.0.0
-pkgrel=3
+pkgver=1.1.0
+pkgrel=0
 upstream_author="NohamR"
 category="ui"
 pkgdesc="Removes the Convert to text option from selection menus and the toolbar."

--- a/packages/sidebar-clock/VELBUILD
+++ b/packages/sidebar-clock/VELBUILD
@@ -1,19 +1,19 @@
 maintainer="Mitchell Scott <mitchell@scottlabs.io>"
-status="unmaintained"
+status="maintained"
 pkgname=sidebar-clock
 pkgver=1.0.0
-pkgrel=2
+pkgrel=3
 upstream_author="NohamR"
 category="ui"
 pkgdesc="Adds a live clock to the library sidebar; tap the entry to toggle seconds display."
 url="https://github.com/NohamR/xovi-qmd-extensions"
 arch="noarch"
 license="MIT"
-depends="qt-resource-rebuilder remarkable-os>=3.23 remarkable-os<3.24"
-_commit="17898d11afc96767842507cc2a9606a974ae5ec5"
+depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
+_commit="86e43a4d8d26c49abcc81f149245ff1f52961124"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md"
 source="
-clock.qmd::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.23.0.64/clock.qmd
+clock.qmd::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27.3.0/clock.qmd
 LICENSE::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="!check !fhs"
@@ -28,6 +28,6 @@ package() {
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
 }
 sha512sums="
-28cc27547f21f246345d240d2e2ce40c0aed6401a1dceebf133d36ca2c37a0a5af8a25001e48d4006a8cf7177464838b303b9a1f816e6eaf3c594a4709304c81  clock.qmd
+33ccbedda414a79a7cf6bf3e74b07b92d129c3d5d0bf78e4978536a4a3f1f696d8d26bb75be3c72f9cce8629a9491df03b49e529c68222a9451bcbaa62ad6279  clock.qmd
 f0ca1d1c12e36cf1a6ea8a55e96186b2157d168bebf838704f18b9eaea043c98993ea25a8e99e2b704065534dd7f9a5e3a563b856a57d97eef40c057b2df4caa  LICENSE
 "

--- a/packages/sidebar-clock/VELBUILD
+++ b/packages/sidebar-clock/VELBUILD
@@ -10,7 +10,7 @@ url="https://github.com/NohamR/xovi-qmd-extensions"
 arch="noarch"
 license="MIT"
 depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
-_commit="86e43a4d8d26c49abcc81f149245ff1f52961124"
+_commit="28fe82a3bca3f13b3834d73755f85b12448190ea"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md"
 source="
 clock.qmd::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27.3.0/clock.qmd

--- a/packages/sidebar-clock/VELBUILD
+++ b/packages/sidebar-clock/VELBUILD
@@ -1,8 +1,8 @@
-maintainer="Mitchell Scott <mitchell@scottlabs.io>"
+maintainer="NohamR <noham@noh.am>"
 status="maintained"
 pkgname=sidebar-clock
-pkgver=1.0.0
-pkgrel=3
+pkgver=1.1.0
+pkgrel=0
 upstream_author="NohamR"
 category="ui"
 pkgdesc="Adds a live clock to the library sidebar; tap the entry to toggle seconds display."
@@ -28,6 +28,6 @@ package() {
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
 }
 sha512sums="
-33ccbedda414a79a7cf6bf3e74b07b92d129c3d5d0bf78e4978536a4a3f1f696d8d26bb75be3c72f9cce8629a9491df03b49e529c68222a9451bcbaa62ad6279  clock.qmd
+1e4a0e43a28fc8be15453e44cc86707a557f34b29e692f18e66e7651b62eb5bb33992eec9cc12c8e1afbf03d80280b8b35a8d48d56626b75fb250b4bb02f5bdd  clock.qmd
 f0ca1d1c12e36cf1a6ea8a55e96186b2157d168bebf838704f18b9eaea043c98993ea25a8e99e2b704065534dd7f9a5e3a563b856a57d97eef40c057b2df4caa  LICENSE
 "

--- a/packages/uncompress-dock/VELBUILD
+++ b/packages/uncompress-dock/VELBUILD
@@ -1,8 +1,8 @@
-maintainer="Mitchell Scott <mitchell@scottlabs.io>"
+maintainer="NohamR <noham@noh.am>"
 status="maintained"
 pkgname=uncompress-dock
-pkgver=1.0.0
-pkgrel=3
+pkgver=1.1.0
+pkgrel=0
 upstream_author="NohamR"
 category="ui"
 pkgdesc="Replaces the More menu in the document dock with dedicated notebook, folder, and quick sheet buttons."


### PR DESCRIPTION
Update convert-to-text-remover, sidebar-clock, and uncompress-dock packages to target latest OS version: 3.27.3.0 (and mark them as maintained).

Add new battery-percentage package.