### PR TITLE
gomarkablestream: rm2 support

### DIFF
--- a/packages/gomarkablestream/VELBUILD
+++ b/packages/gomarkablestream/VELBUILD
@@ -8,7 +8,7 @@ pkgdesc="Stream your reMarkable screen to a web browser"
 url="https://github.com/owulveryck/goMarkableStream"
 arch="aarch64 armv7"
 license="MIT"
-depends="!rmppm !rm1 !rm2 !rmppure remarkable-os>=3.24"
+depends="!rmppm !rm1 !rmppure remarkable-os>=3.24"
 options="!check !fhs !strip !tracedeps"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/goMarkableStream/v$pkgver/README.md"
 


### PR DESCRIPTION
I think there was an error in https://github.com/vellum-dev/vellum/commit/6369624dfce1b78372b46c96aa796138ee2e39c7 when bumping to remove support rm2. 

As per readme, this package should work well on rm2