### PR TITLE
quicksettings-timer: new package

### DIFF
--- a/packages/quicksettings-timer/VELBUILD
+++ b/packages/quicksettings-timer/VELBUILD
@@ -9,8 +9,8 @@ pkgdesc="Adds a countdown timer and stopwatch to the quick settings panel."
 url="https://github.com/NohamR/xovi-qmd-extensions"
 arch="noarch"
 license="MIT"
-depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
-_commit="f1da1d19a6cec3eab74645c2ffd82c3142a6584b"
+depends="qt-resource-rebuilder remarkable-os>=3.24 remarkable-os<3.28"
+_commit="8d00f8633eb4ca341e2eb184bb77af9435d61714"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md"
 source="
 quickSettingsTimer.qmd::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27.3.0/quickSettingsTimer.qmd
@@ -27,7 +27,12 @@ package() {
 	echo "https://github.com/NohamR/xovi-qmd-extensions" > \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
 }
+postdeinstall() {
+	if [ "$VELLUM_PURGE" = "1" ]; then
+		rm -f /home/root/alarms.json
+	fi
+}
 sha512sums="
-03118952aee470a0246c8ba14af3cc00673b36844c9fe92d2c60b2890447d0ab66d086468c6361e927b267cb4b900cfd2e886f9c797a3a1f3c51667acb4c733a  quickSettingsTimer.qmd
+d5fc3ad6569cf06af30b1568b395a529042d10d0f418d733ad9b61c09274bf551f447f82d48b933e3d4b32cad9735c2693986d12f93a96b0bef67f4b52b80a26  quickSettingsTimer.qmd
 f0ca1d1c12e36cf1a6ea8a55e96186b2157d168bebf838704f18b9eaea043c98993ea25a8e99e2b704065534dd7f9a5e3a563b856a57d97eef40c057b2df4caa  LICENSE
 "

--- a/packages/quicksettings-timer/VELBUILD
+++ b/packages/quicksettings-timer/VELBUILD
@@ -10,7 +10,7 @@ url="https://github.com/NohamR/xovi-qmd-extensions"
 arch="noarch"
 license="MIT"
 depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
-_commit="7bf4c219e4bb5fdf1c4d2417eea125907db5c22e"
+_commit="f1da1d19a6cec3eab74645c2ffd82c3142a6584b"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md"
 source="
 quickSettingsTimer.qmd::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27.3.0/quickSettingsTimer.qmd
@@ -28,6 +28,6 @@ package() {
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
 }
 sha512sums="
-e3bad3ff57efb17408a4e2974dff0717edd7e221b4869217031394b7c351fac73ede9713ea12af803d335323812f48e6d1e7f0ffed7fe0a33c1354689f4a5676  quickSettingsTimer.qmd
+03118952aee470a0246c8ba14af3cc00673b36844c9fe92d2c60b2890447d0ab66d086468c6361e927b267cb4b900cfd2e886f9c797a3a1f3c51667acb4c733a  quickSettingsTimer.qmd
 f0ca1d1c12e36cf1a6ea8a55e96186b2157d168bebf838704f18b9eaea043c98993ea25a8e99e2b704065534dd7f9a5e3a563b856a57d97eef40c057b2df4caa  LICENSE
 "

--- a/packages/quicksettings-timer/VELBUILD
+++ b/packages/quicksettings-timer/VELBUILD
@@ -10,7 +10,7 @@ url="https://github.com/NohamR/xovi-qmd-extensions"
 arch="noarch"
 license="MIT"
 depends="qt-resource-rebuilder remarkable-os>=3.24 remarkable-os<3.28"
-_commit="8d00f8633eb4ca341e2eb184bb77af9435d61714"
+_commit="404c970f3602a970e899fe150245826552d5614d"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md"
 source="
 quickSettingsTimer.qmd::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27.3.0/quickSettingsTimer.qmd
@@ -33,6 +33,6 @@ postdeinstall() {
 	fi
 }
 sha512sums="
-d5fc3ad6569cf06af30b1568b395a529042d10d0f418d733ad9b61c09274bf551f447f82d48b933e3d4b32cad9735c2693986d12f93a96b0bef67f4b52b80a26  quickSettingsTimer.qmd
+5a5694491ffcdc2fed1918aa3b642cb7925c49106827185118c57741b29015e6c68989fff907a55e8fb1096b0ecd7cfbc0cd5c77b6bea8d6afaee5b9b77efc2a  quickSettingsTimer.qmd
 f0ca1d1c12e36cf1a6ea8a55e96186b2157d168bebf838704f18b9eaea043c98993ea25a8e99e2b704065534dd7f9a5e3a563b856a57d97eef40c057b2df4caa  LICENSE
 "

--- a/packages/quicksettings-timer/VELBUILD
+++ b/packages/quicksettings-timer/VELBUILD
@@ -1,0 +1,33 @@
+maintainer="NohamR <noham@noh.am>"
+status="maintained"
+pkgname=quicksettings-timer
+pkgver=1.0.0
+pkgrel=0
+upstream_author="NohamR"
+category="ui"
+pkgdesc="Adds a countdown timer and stopwatch to the quick settings panel."
+url="https://github.com/NohamR/xovi-qmd-extensions"
+arch="noarch"
+license="MIT"
+depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
+_commit="7bf4c219e4bb5fdf1c4d2417eea125907db5c22e"
+readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md"
+source="
+quickSettingsTimer.qmd::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27.3.0/quickSettingsTimer.qmd
+LICENSE::https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
+"
+options="!check !fhs"
+
+package() {
+	install -Dm644 "$srcdir/quickSettingsTimer.qmd" \
+		"$pkgdir/home/root/xovi/exthome/qt-resource-rebuilder/quickSettingsTimer.qmd"
+
+	install -Dm644 "$srcdir/LICENSE" \
+		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"
+	echo "https://github.com/NohamR/xovi-qmd-extensions" > \
+		"$pkgdir/home/root/.vellum/licenses/$pkgname/SOURCES"
+}
+sha512sums="
+e3bad3ff57efb17408a4e2974dff0717edd7e221b4869217031394b7c351fac73ede9713ea12af803d335323812f48e6d1e7f0ffed7fe0a33c1354689f4a5676  quickSettingsTimer.qmd
+f0ca1d1c12e36cf1a6ea8a55e96186b2157d168bebf838704f18b9eaea043c98993ea25a8e99e2b704065534dd7f9a5e3a563b856a57d97eef40c057b2df4caa  LICENSE
+"


### PR DESCRIPTION
Adds a countdown timer and stopwatch to the quick settings panel, with preset buttons (1m/5m/10m/30m/1h), start/stop/reset controls, add/set mode toggle, and a notification banner when the timer finishes. 
Source: [quickSettingsTimer.qmd](https://github.com/NohamR/xovi-qmd-extensions/blob/main/3.27.3.0/quickSettingsTimer.qmd)