### PR TITLE
dictionary-wiki-translator: new package

### DIFF
--- a/packages/dictionary-wiki-translator/VELBUILD
+++ b/packages/dictionary-wiki-translator/VELBUILD
@@ -1,5 +1,5 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
-pkgname=dictionary
+pkgname=dictionary-wiki-translator
 pkgver=1.0.0
 pkgrel=0
 upstream_author="alefaraci"
@@ -9,18 +9,18 @@ url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
 depends="qt-resource-rebuilder qt-command-executor remarkable-os>=3.25 remarkable-os<3.28"
-_commit="878eb9e5883f5b33412b377a78d1c8af63d7701c"
+_commit="978166ba46772304178b28a19e50eea8a84a7994"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#dictionary"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/dictionary.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/dictionary-wiki-translator.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="!check !fhs"
 
 package() {
-	install -Dm644 "$srcdir"/dictionary.qmd \
-		"$pkgdir"/home/root/xovi/exthome/qt-resource-rebuilder/dictionary.qmd
+	install -Dm644 "$srcdir"/dictionary-wiki-translator.qmd \
+		"$pkgdir"/home/root/xovi/exthome/qt-resource-rebuilder/dictionary-wiki-translator.qmd
 
 	install -Dm644 "$srcdir"/LICENSE \
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/LICENSE
@@ -28,6 +28,6 @@ package() {
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
 }
 sha512sums="
-7c9bf79d2561caefb7e8e672ee6f2fb3084a3416ebbfcd7efecf1e04ce77cf1d841f9d3b632f5def4eaf5dcd65678eff605eda4af72271615d2103adc9ec035d  dictionary.qmd
+7c9bf79d2561caefb7e8e672ee6f2fb3084a3416ebbfcd7efecf1e04ce77cf1d841f9d3b632f5def4eaf5dcd65678eff605eda4af72271615d2103adc9ec035d  dictionary-wiki-translator.qmd
 6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
 "

--- a/packages/dictionary-wiki-translator/VELBUILD
+++ b/packages/dictionary-wiki-translator/VELBUILD
@@ -9,25 +9,33 @@ url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
 depends="qt-resource-rebuilder qt-command-executor remarkable-os>=3.25 remarkable-os<3.28"
-_commit="978166ba46772304178b28a19e50eea8a84a7994"
+_commit="7d2fceff5a2374c5690c386a1cd361c54db5dbf3"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#dictionary"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/dictionary-wiki-translator.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/dictionaryWikiTranslator.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="!check !fhs"
 
 package() {
-	install -Dm644 "$srcdir"/dictionary-wiki-translator.qmd \
-		"$pkgdir"/home/root/xovi/exthome/qt-resource-rebuilder/dictionary-wiki-translator.qmd
+	install -Dm644 "$srcdir"/dictionaryWikiTranslator.qmd \
+		"$pkgdir"/home/root/xovi/exthome/qt-resource-rebuilder/dictionaryWikiTranslator.qmd
 
 	install -Dm644 "$srcdir"/LICENSE \
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/LICENSE
 	echo "$url" > \
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
 }
+
+postdeinstall() {
+	if [ "$VELLUM_PURGE" = "1" ]; then
+		rm -f /home/root/.config/dictionary-wiki-translator.json
+		rm -rf /home/root/dictionary
+	fi
+}
+
 sha512sums="
-7c9bf79d2561caefb7e8e672ee6f2fb3084a3416ebbfcd7efecf1e04ce77cf1d841f9d3b632f5def4eaf5dcd65678eff605eda4af72271615d2103adc9ec035d  dictionary-wiki-translator.qmd
+b2faf20fb66660130154920d7ddb1af35527fb8aac8748ba9b27437da9e0ff06aca4c40e68d392555c02b5f9bd2f5c5c9a22f3753ce1c66198b2afbf3448c533  dictionaryWikiTranslator.qmd
 6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
 "

--- a/packages/dictionary/VELBUILD
+++ b/packages/dictionary/VELBUILD
@@ -1,0 +1,33 @@
+maintainer="Alessio Faraci <contact@afaraci.com>"
+pkgname=dictionary
+pkgver=1.0.0
+pkgrel=0
+upstream_author="alefaraci"
+category="ui"
+pkgdesc="Adds integrated dictionary, Wikipedia, and translation capabilities for PDFs and EPUBs"
+url="https://github.com/alefaraci/xovi-qmd-extensions"
+arch="noarch"
+license="GPL-3.0-only"
+depends="qt-resource-rebuilder qt-command-executor remarkable-os>=3.25 remarkable-os<3.28"
+_commit="878eb9e5883f5b33412b377a78d1c8af63d7701c"
+readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#dictionary"
+donateurl="https://buymeacoffee.com/afaraci"
+source="
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/dictionary.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
+"
+options="!check !fhs"
+
+package() {
+	install -Dm644 "$srcdir"/dictionary.qmd \
+		"$pkgdir"/home/root/xovi/exthome/qt-resource-rebuilder/dictionary.qmd
+
+	install -Dm644 "$srcdir"/LICENSE \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/LICENSE
+	echo "$url" > \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
+}
+sha512sums="
+7c9bf79d2561caefb7e8e672ee6f2fb3084a3416ebbfcd7efecf1e04ce77cf1d841f9d3b632f5def4eaf5dcd65678eff605eda4af72271615d2103adc9ec035d  dictionary.qmd
+6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
+"


### PR DESCRIPTION
Adds `dictionary-wiki-translator` extension: integrated dictionary, Wikipedia, and translation capabilities for PDFs and EPUBs. By lassoing a word or phrase and tapping the book icon in the selection menu, a bottom panel opens with three tabs:
1. **Dictionary**: Offline (download up to 3 of 12 available languages via Settings)
2. **Encyclopedia**: Online (fetches summaries)
3. **Translator**: Online with MyMemory  (works instantly without an API key) and DeepL (requires to set an API key from [deepl.com/pro#api](https://www.deepl.com/pro#api))

The mod is customizable via the dedicated **Settings ▸ Dictionary** page. Download up to 3 of 12 available offline dictionary languages, select the preferred translation service (MyMemory / DeepL), and input the DeepL API key.

- **Upstream**: [https://github.com/alefaraci/xovi-qmd-extensions](https://github.com/alefaraci/xovi-qmd-extensions) 
- **License**: GPL-3.0-only · **arch**: noarch
- **Depends**: `qt-resource-rebuilder` `qt-command-executor`
- **Conflicts**:  none
- **Device/OS**: working on all devices remarkable-os>=3.25 <3.28 according to [https://qmdverify.scottlabs.io/](https://qmdverify.scottlabs.io/) — tested only on my device (RMPPure OS 3.27).

<img width="256" height="123" alt="Selection dict" src="https://github.com/user-attachments/assets/3bedfe3f-ef14-483d-82fc-d424029a1067" />


| ![dictionary](https://github.com/user-attachments/assets/edc0c0dd-a981-4bce-aa18-07f2bae733e4) | ![wiki](https://github.com/user-attachments/assets/95e45794-e20a-4a38-b1a5-01d52b1c51d2)  |
|:---:|:---:|

| ![deepl](https://github.com/user-attachments/assets/b062ac91-d48a-4692-9fce-f65656406770) | ![settings](https://github.com/user-attachments/assets/2ea25d81-4b6e-44b3-8744-cf9e1fdccd32)  |
|:---:|:---:|
