### PR TITLE
navhistory: upgrade to v1.1.0

### DIFF
--- a/packages/nav-history/VELBUILD
+++ b/packages/nav-history/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=nav-history
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -9,7 +9,7 @@ url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
 depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
-_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+_commit="1e7392ad13a563b5149eb03cc1ef24c4fca2e498"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#navhistory"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
@@ -28,6 +28,6 @@ package() {
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
 }
 sha512sums="
-d234528db7f37d7e05b9207d76c67a2997cd763bdae6d89146d6f67fdad5b9d1bc413184832eebf0507ef10924a289f3271c5107843b3ad621235426f9d3eb07  navHistory.qmd
+17601c7f1df5f595d337910bec31b8be31163d7f54c2c8aeaf9bcce338070052c75bb736dc0af942e619b05ec2d6de0afeac67a8bbf45ee713976812223ae212  navHistory.qmd
 6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
 "


### PR DESCRIPTION
Upgrade navhistory mod v1.0.0 → v1.1.0.

### New in v1.1.0
- Added a "back to the previous opened file" button.

<img width="600" alt="NavHistory" src="https://github.com/user-attachments/assets/adb9651d-90a1-430f-b96e-8dc756601f0b" />
