### PR TITLE
gestik: upgrade to v1.1.1

### DIFF
--- a/packages/gestik/VELBUILD
+++ b/packages/gestik/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=gestik
-pkgver=1.1.0
+pkgver=1.1.1
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,8 +8,8 @@ pkgdesc="Configurable multi-finger gestures for tool switching or action you wan
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder !gestures-fouzr !gestures-ingatellent !four-finger-change-filter !three-finger-swipe-to-reset-view remarkable-os>=3.27 remarkable-os<3.28"
-_commit="1a94f25fca7abefcd0211a3a433f5a502191b1a6"
+depends="qt-resource-rebuilder !gestures-fouzr !gestures-ingatellent !four-finger-change-filter !three-finger-swipe-to-reset-view remarkable-os>=3.25 remarkable-os<3.28"
+_commit="974c07f11c2c48285a59c9ddf428773c2f962d5d"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#gestik"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
@@ -27,7 +27,14 @@ package() {
 	echo "$url" > \
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
 }
+
+postdeinstall() {
+	if [ "$VELLUM_PURGE" = "1" ]; then
+		rm -f /home/root/.config/gestik.json
+	fi
+}
+
 sha512sums="
-1f1f5817b26d8359754c3397c9cb7c6a0ff49d30af6b6d8f55470a653d7c752b2fcc4ac4af9dae63cdd03da0c482061176dbe95c554eb300133b2ee48b4d6fe2  gestik.qmd
+3058b754709f803cf0fa28473d8dbac20ee551dc88afff2a4a6e302fb1ac9e250c71a679e5a0f2924a529195874e8c8f24e8472ca79067bd5ca255a105719676  gestik.qmd
 6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
 "


### PR DESCRIPTION
Upgrade gestik mod v1.1.0 → v1.1.1.

- Fix issue [(#5)](https://github.com/alefaraci/xovi-qmd-extensions/issues/5) – eraser icon bleeding into pen toolbar slot after switching out of the eraser tool.
- Extend OS compatibility: working on all devices remarkable-os>=3.25 <3.28 according to https://qmdverify.scottlabs.io/
- `VELBUILD` adds `postdeinstall()` hook. On vellum purge (VELLUM_PURGE=1) it removes the config file.