### PR TITLE
visible-sleep-screen : new package

### DIFF
--- a/packages/visible-sleep-screen/VELBUILD
+++ b/packages/visible-sleep-screen/VELBUILD
@@ -9,7 +9,7 @@ url="https://github.com/alefaraci/xovi-qmd-extensions#visiblesleepscreen"
 arch="noarch"
 license="GPL-3.0-only"
 depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
-_commit="b449fe50dc0a2469df4244d74efa42703ab7bf70"
+_commit="3d2735d97ab040b2d7de1709eee7a9bb13f306c1"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#visiblesleepscreen"
 source="
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/visibleSleepScreen.qmd
@@ -28,6 +28,6 @@ package() {
 }
 
 sha512sums='
-72c7e7c989d0eeb8593d0c24d3c6b5aabd9b7928ae8a8fbfb52f54d25015f149ba2e718e5ea28457e127079fca4406876e0be28d030e47e09bd471d3357b653b  visibleSleepScreen.qmd
+02f9ff8ca2fcf1357799ec979edf177c48917301bc8619609195c4b925c5dcc56ab34d93d663e8b3830ad046dbe60a70647177b1a5a4735f400cca42865cd316  visibleSleepScreen.qmd
 6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
 '

--- a/packages/visible-sleep-screen/VELBUILD
+++ b/packages/visible-sleep-screen/VELBUILD
@@ -1,0 +1,33 @@
+maintainer="Alessio Faraci <contact@afaraci.com>"
+pkgname=visible-sleep-screen
+pkgver=1.0.0
+pkgrel=0
+upstream_author="alefaraci"
+category="ui"
+pkgdesc="Transparent sleep screen. It shows the page you were on as the sleep screen, instead of the reMarkable logo."
+url="https://github.com/alefaraci/xovi-qmd-extensions#visiblesleepscreen"
+arch="noarch"
+license="GPL-3.0-only"
+depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
+_commit="b449fe50dc0a2469df4244d74efa42703ab7bf70"
+readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#visiblesleepscreen"
+source="
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/visibleSleepScreen.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
+"
+options="strip tracedeps"
+
+package() {
+	install -Dm644 "$srcdir"/visibleSleepScreen.qmd \
+		"$pkgdir"/home/root/xovi/exthome/qt-resource-rebuilder/visibleSleepScreen.qmd
+
+	install -Dm644 "$srcdir"/LICENSE \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/LICENSE
+	echo "https://github.com/$upstream_author/xovi-qmd-extensions" > \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
+}
+
+sha512sums='
+72c7e7c989d0eeb8593d0c24d3c6b5aabd9b7928ae8a8fbfb52f54d25015f149ba2e718e5ea28457e127079fca4406876e0be28d030e47e09bd471d3357b653b  visibleSleepScreen.qmd
+6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
+'


### PR DESCRIPTION
`visible-sleep-screen` sets visible content as sleep screen when "Visible content" (Settings ▸ Display ▸ "Visible content") is ON. It renders the stock screen when "Visible content" is OFF. The device still performs a real deep-sleep. 

Optional owner info: if Settings ▸ Security ▸ Personal information is ON, the sleep bar appends `Name – Contact`.

- **Upstream:** https://github.com/alefaraci/xovi-qmd-extensions#visiblesleepscreen
- **License:** GPL-3.0-only
- **Arch:** noarch
- **Depends on** `qt-resource-rebuilder`.
- **Device/OS**: all devices, `remarkable-os>=3.27 <3.28`.

**Note on hashing:** the hashtab is built per-device from that device's own xochitl, so tokens that exist on only one model (the two sleep-window paths, `folioClosed`, the folio-peek ids) are deliberately left *cleartext*. Hashing them, I experienced that would make the file unresolvable on the other device, which fails the `.qmd` and every other installed mod with it. A fully-hashed multi-device `.qmd` isn't possible apparently; this is the reason the file looks partly cleartext. The whole `MainView.qml` block is also kept cleartext on purpose. That exact form is the one I device-verified on both models.

## Testing

Device-verified end-to-end on:

- ✅ reMarkable Paper Pure (`tatsu`, aarch64) — xochitl 3.27.3.1547
- ✅ reMarkable 2 (armv7) — xochitl 3.27.3.1547

Not tested: 
- Paper Pro (`ferrari`) 
- Paper Pro Move (`chiappa`)

I don't own either, so I want to be upfront about where they could break:

- **⚠️ A different sleep-window path (most likely).** Since binaries are per-device, Pro/Move may use neither `qml/tatsu/` nor `qml/default/` but a path of their own. Consequence is benign: `qt-resource-rebuilder` just never matches it, so the sleep screen stays stock: no crash, no impact on other mods. (The `MainView.qml` block would still apply, also benign: with the stock opaque sleep window on top nothing shows through, so the visible effect is only that the sleep-entry white flash is gone while "Visible content" is ON.) The fix would be one extra `AFFECT` line reusing the same `SLOT`, once someone reports the path (or shares their xochitl).

<img width="500" alt="Visible Sleep Screen Portrait" src="https://github.com/user-attachments/assets/72149463-3f30-4146-a094-241e359cebdb" />
