### PR TITLE
Package cleanup

### DIFF
--- a/packages/doomarkable/VELBUILD
+++ b/packages/doomarkable/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=doomarkable
 pkgver=0.4.2
-pkgrel=0
+pkgrel=1
 pkgdesc="DOOM game"
 upstream_author="LinusCDE"
 category="apps"
@@ -14,7 +14,6 @@ https://github.com/LinusCDE/doomarkable/archive/$pkgver.zip
 external.manifest.aarch64.json
 external.manifest.armv7.json
 "
-options="!check !fhs !strip !tracedeps"
 depends="appload>=0.5.3 !rmppure !rm2"
 
 image="ghcr.io/toltec-dev/rust:v4.0"

--- a/packages/entware/VELBUILD
+++ b/packages/entware/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Mitchell Scott <mitchell@scottlabs.io>"
 pkgname=entware
 pkgver=1.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Entware software repository for reMarkable tablets"
 upstream_author="Entware"
 category="utilities"
@@ -78,9 +78,9 @@ postinstall() {
 
 	cat <<'EOF'
 
-======================================================
+=======================================================
                   Entware Installed
-======================================================
+=======================================================
 
   Package management:
 
@@ -94,7 +94,7 @@ postinstall() {
 
     /home/root/.local/share/entware/reenable-entware.sh
 
-======================================================
+=======================================================
 EOF
 
 	if [ "$BASHRC_CHANGED" = true ]; then
@@ -116,9 +116,9 @@ postupgrade() {
 
 	cat <<'EOF'
 
-======================================================
+=======================================================
                   Entware Upgraded
-======================================================
+=======================================================
 
   The opkg package manager has been updated.
   Your installed Entware packages are preserved.
@@ -127,7 +127,7 @@ postupgrade() {
 
     opkg update && opkg upgrade
 
-======================================================
+=======================================================
 
 EOF
 }
@@ -170,9 +170,9 @@ postdeinstall() {
 	elif [ -d "$ENTWARE_DATA" ]; then
 		cat <<'EOF'
 
-======================================================
+=======================================================
     Entware data preserved at /home/root/.entware
-======================================================
+=======================================================
 
   Your Entware packages and settings are still on disk.
 
@@ -184,7 +184,7 @@ postdeinstall() {
 
     vellum install entware
 
-======================================================
+=======================================================
 
 EOF
 	fi

--- a/packages/external-keyboard-qpa/VELBUILD
+++ b/packages/external-keyboard-qpa/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Mitchell Scott <mitchell@scottlabs.io>"
 pkgname=external-keyboard-qpa
 pkgver=0.1.0
-pkgrel=0
+pkgrel=1
 upstream_author="rmitchellscott"
 category="framework"
 pkgdesc="Qt platform plugin for reMarkable e-paper displays with external keyboard support"
@@ -9,7 +9,6 @@ url="https://github.com/rmitchellscott/epaper-qpa"
 arch="aarch64"
 license="LGPL-2.1-only"
 depends="xovi qt-plugin-path"
-options="!check !fhs !strip !tracedeps"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/epaper-qpa/external-keyboard/README.md"
 donateurl="https://buymeacoffee.com/rmitchellscott"
 source="

--- a/packages/koreader/VELBUILD
+++ b/packages/koreader/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Mitchell Scott <mitchell@scottlabs.io>"
 pkgname=koreader
 pkgver=2026.03
-pkgrel=4
+pkgrel=5
 upstream_author="koreader"
 category="apps"
 pkgdesc="An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats."
@@ -38,25 +38,10 @@ package() {
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
 }
 
-postinstall() {
-	echo ""
-	echo "=================================================="
-	echo "  NOTE: To use KOReader, you must refresh AppLoad"
-	echo "=================================================="
-	echo ""
-}
-
 postdeinstall() {
 	if [ "$VELLUM_PURGE" = "1" ]; then
 		rm -rf /home/root/xovi/exthome/appload/koreader
 	fi
-
-	echo ""
-	echo "==============================================="
-	echo "  NOTE: You must refresh AppLoad to see changes "
-	echo "  reflected in the tablet UI "
-	echo "==============================================="
-	echo ""
 }
 
 sha512sums='

--- a/packages/retaskable/VELBUILD
+++ b/packages/retaskable/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Jarett <jarett@reticulum.us>"
 pkgname=retaskable
 pkgver=1.0.5
-pkgrel=0
+pkgrel=1
 upstream_author="jdkruzr"
 category="utilities"
 pkgdesc="CalDAV task client for reMarkable tablets"
@@ -9,7 +9,6 @@ url="https://github.com/jdkruzr/reTaskable"
 arch="aarch64 armv7"
 license="GPL-3.0-only"
 depends="appload"
-options="!check !fhs !strip !tracedeps"
 subpackages="retaskable-capture:capture"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/reTaskable/v$pkgver/README.md"
 

--- a/packages/rmfakecloud-proxy/VELBUILD
+++ b/packages/rmfakecloud-proxy/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Mitchell Scott <mitchell@scottlabs.io>"
 pkgname=rmfakecloud-proxy
 pkgver=0.0.10
-pkgrel=1
+pkgrel=2
 pkgdesc="HTTPS proxy for rmfakecloud - redirects reMarkable cloud traffic"
 upstream_author="ddvk"
 category="utilities"
@@ -33,9 +33,9 @@ package() {
 postinstall() {
 	cat <<'EOF'
 
-══════════════════════════════════════════════════════════════════
-                    rmfakecloud-proxy installed
-══════════════════════════════════════════════════════════════════
+═══════════════════════════════════════════════════════
+              rmfakecloud-proxy installed
+═══════════════════════════════════════════════════════
 
   To complete setup, run:
 
@@ -43,13 +43,14 @@ postinstall() {
 
   You will be prompted for your rmfakecloud server URL.
 
-  IMPORTANT: You must re-run the installer after each OS update!
+  IMPORTANT: You must re-run the installer after each
+             OS update!
 
   Other commands:
     install.sh setcloud    - Change the cloud URL
     install.sh gencert     - Regenerate certificates
 
-══════════════════════════════════════════════════════════════════
+═══════════════════════════════════════════════════════
 
 EOF
 }

--- a/packages/rmstream/VELBUILD
+++ b/packages/rmstream/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Mitchell Scott <mitchell@scottlabs.io>"
 pkgname=rmstream
 pkgver=0.1.5
-pkgrel=0
+pkgrel=1
 upstream_author="asivery"
 category="apps"
 pkgdesc="Stream your reMarkable's screen to any device on the local network via HTTP"
@@ -34,24 +34,6 @@ package() {
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/LICENSE
 	echo "https://github.com/asivery/appload-rmstream/archive/v$pkgver.tar.gz" > \
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
-}
-
-postinstall() {
-	echo ""
-	echo "==============================================="
-	echo "  NOTE: You must refresh AppLoad to see changes "
-	echo "  reflected in the tablet UI "
-	echo "==============================================="
-	echo ""
-}
-
-postdeinstall() {
-	echo ""
-	echo "==============================================="
-	echo "  NOTE: You must refresh AppLoad to see changes "
-	echo "  reflected in the tablet UI "
-	echo "==============================================="
-	echo ""
 }
 
 sha512sums='150322f05ad36257e91c20eb15370a620feac125ffcae9a32c6375fe3a102cd1e44e2382c0a26e2f689c608dda6c0a90e9af5718ebbadf148a63b3a56e3249b2

--- a/packages/starship/VELBUILD
+++ b/packages/starship/VELBUILD
@@ -2,7 +2,7 @@ maintainer="Mitchell Scott <mitchell@scottlabs.io>"
 status=unmaintained
 pkgname=starship
 pkgver=1.24.2
-pkgrel=2
+pkgrel=3
 upstream_author="starship"
 category="utilities"
 pkgdesc="The minimal, blazing-fast, and infinitely customizable prompt for any shell!"
@@ -38,16 +38,16 @@ postinstall() {
 	/home/root/.vellum/bin/starship completions bash > \
 		/home/root/.vellum/share/bash-completion/completions/starship
 
-	echo ""
-	echo "==========================================================================="
-	echo "  NOTE: To enable starship, you must add"
-	echo '  `eval "$(starship init bash)"`'
-	echo "  to the end of ~/.bashrc."
-	echo ""
-	echo "  See https://starship.rs/guide/#step-2-set-up-your-shell-to-use-starship"
-	echo "  for more information."
-	echo "==========================================================================="
-	echo ""
+	cat <<'EOF'
+======================================================
+  NOTE: To enable starship, you must add
+  `eval "$(starship init bash)"`
+  to the end of your ~/.bashrc
+
+  For more information see:
+  https://starship.rs/guide/#step-2-set-up-your-shell-to-use-starship
+======================================================
+EOF
 }
 
 postupgrade() {

--- a/packages/tailscale/VELBUILD
+++ b/packages/tailscale/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Interloper <45214659+0xdeb7ef@users.noreply.github.com>"
 pkgname=tailscale
 pkgver=1.98.8
-pkgrel=0
+pkgrel=1
 upstream_author="tailscale"
 category="utilities"
 pkgdesc="Tailscale VPN client"
@@ -59,7 +59,6 @@ package() {
 
 postdeinstall() {
 	if [ "$VELLUM_PURGE" = "1" ]; then
-		echo "deleting tailscale config files..."
 		rm -rf \
 			/home/root/.local/var/lib/tailscale \
 			/home/root/.config/tailscale
@@ -72,27 +71,20 @@ tun() {
 
 	package() {
 		cd "$srcdir/tailscale"
-
-		# Reset FLAGS
-		sed '/FLAGS/d' systemd/tailscaled.defaults > systemd/tailscaled.tun
-		echo 'FLAGS=""' >> systemd/tailscaled.tun
+		sed '/FLAGS/d' systemd/tailscaled.defaults >systemd/tailscaled.tun
+		echo 'FLAGS=""' >>systemd/tailscaled.tun
 
 		install -Dm644 systemd/tailscaled.tun \
 			"$subpkgdir/home/root/.vellum/etc/default/tailscaled"
 	}
 
 	postinstall() {
-		echo "restarting tailscaled service..."
 		systemctl try-restart tailscaled.service
 	}
 
 	postdeinstall() {
-		# Restore userspace
-		echo "restoring userspace networking..."
 		sed -i '/FLAGS/d' /home/root/.vellum/etc/default/tailscaled
-		echo 'FLAGS="--tun userspace-networking"' >> /home/root/.vellum/etc/default/tailscaled
-
-		echo "restarting tailscaled service..."
+		echo 'FLAGS="--tun userspace-networking"' >>/home/root/.vellum/etc/default/tailscaled
 		systemctl try-restart tailscaled.service
 	}
 }

--- a/packages/vnsee-qtfb/VELBUILD
+++ b/packages/vnsee-qtfb/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Interloper <45214659+0xdeb7ef@users.noreply.github.com>"
 pkgname=vnsee-qtfb
 pkgver=1.1.0
-pkgrel=4
+pkgrel=5
 upstream_author="khyryra"
 category="apps"
 pkgdesc="VNC client for the reMarkable tablet allowing you to use the device as a second screen"
@@ -40,23 +40,18 @@ package() {
 }
 
 postinstall() {
-	echo ""
-	echo "================================================================="
-	echo "  NOTE: You have to update your connection parameters in"
-	echo "   /home/root/xovi/exthome/appload/vnsee-X/external.manifest.json"
-	echo "   Where X is the different vnsee display modes."
-	echo "================================================================="
-	echo ""
+	cat <<'EOF'
+======================================================
+  NOTE: You have to update your connection parameters
+        in
+  ~/xovi/exthome/appload/vnsee-*/external.manifest.json
+        Where * is the different vnsee display modes.
+======================================================
+EOF
 }
 
 postupgrade() {
-	echo ""
-	echo "================================================================="
-	echo "  NOTE: You have to update your connection parameters in"
-	echo "   /home/root/xovi/exthome/appload/vnsee-X/external.manifest.json"
-	echo "   Where X is the different vnsee display modes."
-	echo "================================================================="
-	echo ""
+	postinstall
 }
 
 postdeinstall() {

--- a/packages/xovi-extensions/VELBUILD
+++ b/packages/xovi-extensions/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Mitchell Scott <mitchell@scottlabs.io>"
 pkgname=xovi-extensions
 pkgver=19.0.0
-pkgrel=1
+pkgrel=2
 upstream_author="asivery"
 category="framework"
 pkgdesc="Extensions for xovi framework"
@@ -71,12 +71,12 @@ qt_resource_rebuilder() {
 	depends="$pkgname"
 
 	postinstall() {
-		echo ""
-		echo "============================================"
-		echo "  NOTE: Before using any QT modifications,"
-		echo "  you must run: xovi/rebuild_hashtable"
-		echo "============================================"
-		echo ""
+		cat <<'EOF'
+======================================================
+  NOTE: Before using any QT modifications,
+  you must run: xovi/rebuild_hashtable
+======================================================
+EOF
 	}
 
 	postdeinstall() {
@@ -86,12 +86,7 @@ qt_resource_rebuilder() {
 	}
 
 	postosupgrade() {
-		echo ""
-		echo "==============================================="
-		echo "  NOTE: Before using any QT modifications,"
-		echo "  you must run: xovi/rebuild_hashtable"
-		echo "==============================================="
-		echo ""
+		postinstall
 	}
 
 	package() {


### PR DESCRIPTION
- Unify package messaging to use the same formatting, I've picked an arbitrary max line length of 55 characters for all messages, paths/links are allowed to be longer, but must be on their own line to do so.
- Remove "you must refresh appload" messages
- Removed options that are now default on several packages that were not updated after the repo was updated.