### PR TITLE
Add remarkable-calendar-notes

### DIFF
--- a/packages/remarkable-calendar-notes/VELBUILD
+++ b/packages/remarkable-calendar-notes/VELBUILD
@@ -1,0 +1,58 @@
+maintainer="astafan8 <astafan8@users.noreply.github.com>"
+status="experimental"
+pkgname=remarkable-calendar-notes
+pkgver=0.1.3
+pkgrel=0
+upstream_author="astafan8"
+category="apps"
+pkgdesc="Read-only calendar (Day/Week/Work Week/Two Weeks/Month) with persistent handwritten notes per date, via AppLoad"
+url="https://github.com/astafan8/remarkable-calendar-notes-releases"
+arch="armv7"
+license="MIT"
+# reMarkable 2 only. Vellum's device gating is expressed as exclusions of
+# the devices this package must not install on, alongside its real
+# dependencies: this app is built for RM2's 32-bit armv7 userspace and its
+# 1404x1872 QTFB framebuffer, and is not built or tested for the
+# reMarkable 1, Paper Pro, Paper Pro Move, or Paper Pure.
+depends="appload>=0.5.3 remarkable-os>=3.26 remarkable-os<3.28 !rm1 !rmpp !rmppm !rmppure"
+readmeurl="https://raw.githubusercontent.com/$upstream_author/remarkable-calendar-notes-releases/v$pkgver/README.md"
+source="
+https://github.com/$upstream_author/remarkable-calendar-notes-releases/releases/download/v$pkgver/remarkable-calendar-notes-$pkgver-armv7.zip
+https://raw.githubusercontent.com/$upstream_author/remarkable-calendar-notes-releases/v$pkgver/LICENSE
+"
+options="!check !fhs"
+
+unpack() {
+	unzip -o "$srcdir"/remarkable-calendar-notes-$pkgver-armv7.zip -d "$srcdir"
+}
+
+package() {
+	install -Dm755 "$srcdir"/remarkable-calendar-notes/remarkable-calendar-notes \
+		"$pkgdir"/home/root/xovi/exthome/appload/remarkable-calendar-notes/remarkable-calendar-notes
+	install -Dm644 "$srcdir"/remarkable-calendar-notes/icon.png \
+		"$pkgdir"/home/root/xovi/exthome/appload/remarkable-calendar-notes/icon.png
+	install -Dm644 "$srcdir"/remarkable-calendar-notes/external.manifest.json \
+		"$pkgdir"/home/root/xovi/exthome/appload/remarkable-calendar-notes/external.manifest.json
+
+	install -Dm644 "$srcdir"/LICENSE \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/LICENSE
+	echo "https://github.com/$upstream_author/remarkable-calendar-notes-releases" > \
+		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
+}
+
+predeinstall() {
+	# User data (config, ink notes, offline cache) lives under
+	# /home/root/.local/share/remarkable-calendar-notes and is preserved on
+	# a plain `vellum del`; only `vellum purge` removes it.
+	if [ "$VELLUM_PURGE" = "1" ]; then
+		rm -rf /home/root/.local/share/remarkable-calendar-notes
+	fi
+}
+
+# Generated from the public v0.1.3 distribution release by
+# scripts/update-vellum-checksums.sh. Regenerate whenever pkgver or source=
+# changes; repository checks require real 128-character SHA-512 digests.
+sha512sums="
+477f025b6ff02c7b4dbce88f62995f5bf017f6950ee5193cd0b84a591b97eb7ca9c0b71fb1ec46a891a1ca829aa3a443e0da825930f2de991edfbd241d28be58  remarkable-calendar-notes-0.1.3-armv7.zip
+9f39ea5e24a0eaf3f0e3217170cded95184fe8a6f179d4d19c4c11c110e5be135be23d7edb0b3cec093d1a4ea93ffec753f4b8fcf9b0ac1fc5856f7a95f13773  LICENSE
+"


### PR DESCRIPTION
Adds an experimental reMarkable 2 AppLoad/QTFB calendar with Day, Week, Work Week, Two Weeks, and Month views plus persistent handwritten notes per date.\n\n- Target: rm2 / armv7, reMarkable OS 3.26-3.27\n- Runtime: AppLoad >= 0.5.3\n- Public binary artifacts and license: https://github.com/astafan8/remarkable-calendar-notes-releases/releases/tag/v0.1.3\n- Checksums are pinned to the public v0.1.3 release\n- User data is retained on normal uninstall and removed on purge\n\nThe armv7 binary and packaging pipeline build successfully in GitHub Actions. Physical-device validation is still required, so this is intended for the Vellum testing/review path rather than immediate stable publication. Local Vellum lint could not run because vbuild is not installed on the current workstation; please rely on this PR's repository checks for the authoritative package validation.