### PR TITLE
Upgrade to vbuild 0.0.36

### DIFF
--- a/.github/actions/install-vbuild/action.yaml
+++ b/.github/actions/install-vbuild/action.yaml
@@ -10,6 +10,6 @@ runs:
         set -e
         curl \
           --location \
-          'https://github.com/Eeems/vbuild/releases/download/0.0.34/vbuild-x86_64-glibc' \
+          'https://github.com/Eeems/vbuild/releases/download/0.0.36/vbuild-x86_64-glibc' \
           --output /usr/local/bin/vbuild
         chmod +x /usr/local/bin/vbuild

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ packages/*/*.post-upgrade
 packages/*/*.pre-upgrade
 packages/*/*.build.sh
 packages/*/*.trigger
+packages/*/*.build

--- a/packages/bandwhich/VELBUILD
+++ b/packages/bandwhich/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=bandwhich
 pkgver=0.23.1
-pkgrel=0
+pkgrel=1
 upstream_author="imsnif"
 category="utilities"
 pkgdesc="CLI network utilization tool"
@@ -12,9 +12,11 @@ readmeurl="https://raw.githubusercontent.com/$upstream_author/$pkgname/v$pkgver/
 source="
 https://github.com/$upstream_author/$pkgname/archive/refs/tags/v$pkgver.zip
 "
+options='strip'
 
 image="ghcr.io/toltec-dev/rust:v4.0"
 build() {
+	set -e
 	cd "$srcdir"/"$pkgname"-"$pkgver"
 	case "$CARCH" in
 	aarch64) . /opt/x-tools/switch-aarch64.sh ;;
@@ -26,11 +28,11 @@ build() {
 	esac
 	ls -l
 	cargo build --release
-	"${CROSS_COMPILE}strip" target/"$CARGO_BUILD_TARGET"/release/bandwhich
 	mv target/"$CARGO_BUILD_TARGET"/release/bandwhich .
 }
 
 package() {
+	set -e
 	cd "$srcdir"/"$pkgname"-"$pkgver"
 	install -Dm755 bandwhich \
 		"$pkgdir"/home/root/.vellum/bin/bandwhich

--- a/packages/chessmarkable/VELBUILD
+++ b/packages/chessmarkable/VELBUILD
@@ -2,7 +2,7 @@ maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=chessmarkable
 _pkgver=0.8.1-1
 pkgver=${_pkgver%-*}
-pkgrel=5
+pkgrel=6
 pkgdesc="Chess game"
 upstream_author="LinusCDE"
 category="apps"
@@ -16,6 +16,7 @@ external.manifest.aarch64.json
 external.manifest.armv7.json
 "
 depends="!rmppure launcher"
+options='strip'
 
 image="ghcr.io/toltec-dev/rust:v4.0"
 build() {
@@ -28,14 +29,13 @@ build() {
 		exit 1
 		;;
 	esac
-	_pkgver=0.8.1-1 # $_pkgver is not passed through to build() yet
 	cd "$srcdir/$pkgname-$_pkgver"
 	cargo build --release --bin chessmarkable
 	mv target/$CARGO_BUILD_TARGET/release/chessmarkable .
-	"${CROSS_COMPILE}strip" chessmarkable
 }
 
 package() {
+	set -e
 	cd "$srcdir/$pkgname-$_pkgver"
 	install -Dm644 "LICENSE" \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"

--- a/packages/doomarkable/VELBUILD
+++ b/packages/doomarkable/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=doomarkable
 pkgver=0.4.2
-pkgrel=2
+pkgrel=3
 pkgdesc="DOOM game"
 upstream_author="LinusCDE"
 category="apps"
@@ -15,9 +15,11 @@ external.manifest.aarch64.json
 external.manifest.armv7.json
 "
 depends="launcher !rmppure !rm2"
+options='strip'
 
 image="ghcr.io/toltec-dev/rust:v4.0"
 build() {
+	set -e
 	case "$CARCH" in
 	aarch64) . /opt/x-tools/switch-aarch64.sh ;;
 	armv7) . /opt/x-tools/switch-arm.sh ;;
@@ -31,10 +33,10 @@ build() {
 	cd "$srcdir/$pkgname-$pkgver"
 	cargo build --release
 	mv target/"$CARGO_BUILD_TARGET"/release/doomarkable .
-	"${CROSS_COMPILE}strip" doomarkable
 }
 
 package() {
+	set -e
 	cd "$srcdir/$pkgname-$pkgver"
 	install -Dm644 "LICENSE" \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"

--- a/packages/keyd/VELBUILD
+++ b/packages/keyd/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=keyd
 pkgver=2.6.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A key remapping daemon for linux"
 upstream_author="rvaiya"
 category="utilities"
@@ -15,8 +15,10 @@ default.conf
 "
 subpackages="$pkgname-doc"
 systemdunits="keyd.service"
+options='strip'
 image="ghcr.io/toltec-dev/base:v4.0"
 build() {
+	set -e
 	case "$CARCH" in
 	aarch64) . /opt/x-tools/switch-aarch64.sh ;;
 	armv7) . /opt/x-tools/switch-arm.sh ;;
@@ -29,10 +31,10 @@ build() {
 	make PREFIX=/home/root/.vellum CONFIG_DIR=/home/root/.config/keyd "CC=${CROSS_COMPILE}cc"
 	PREFIX=/home/root/.vellum \
 		sed -e "s|@PREFIX@|/home/root/.vellum|" keyd.service.in >"$srcdir"/keyd.service
-	"${CROSS_COMPILE}strip" bin/keyd
 }
 
 package() {
+	set -e
 	cd "$srcdir/$pkgname-${pkgver%-*}"
 	install -Dm644 "LICENSE" \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"
@@ -48,6 +50,7 @@ package() {
 }
 doc() {
 	package() {
+		set -e
 		mkdir -p "$subpkgdir"/home/root/.vellum/share/
 		mv "$pkgdir"/home/root/.vellum/share/man/ \
 			"$subpkgdir"/home/root/.vellum/share/man/

--- a/packages/netevent/VELBUILD
+++ b/packages/netevent/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=netevent
 pkgver=2.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Input-Event device cloning utility"
 upstream_author="Blub"
 category="utilities"
@@ -10,9 +10,10 @@ arch="armv7 aarch64"
 license="GPL-2.0-only"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/netevent/${pkgver%-*}/README.md"
 source="$pkgname-${pkgver%-*}.tar.gz::https://github.com/$upstream_author/netevent/archive/refs/tags/${pkgver%-*}.tar.gz"
-
+options='strip'
 image="ghcr.io/toltec-dev/base:v4.0"
 build() {
+	set -e
 	case "$CARCH" in
 	aarch64) . /opt/x-tools/switch-aarch64.sh ;;
 	armv7) . /opt/x-tools/switch-arm.sh ;;
@@ -24,10 +25,10 @@ build() {
 	cd "$srcdir/$pkgname-${pkgver%-*}"
 	export CXX="${CROSS_COMPILE}g++"
 	make
-	"${CROSS_COMPILE}strip" netevent
 }
 
 package() {
+	set -e
 	cd "$srcdir/$pkgname-${pkgver%-*}"
 	install -Dm644 "LICENSE" \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"

--- a/packages/netsurf/VELBUILD
+++ b/packages/netsurf/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="maicrohard <maicrohard@proton.me>"
 pkgname=netsurf
 pkgver=0.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Lightweight web browser"
 upstream_author="MaicroNotHard"
 category="apps"
@@ -39,7 +39,6 @@ build() {
 		exit 1
 		;;
 	esac
-	_commit=125e7e10d044e6eef1fa391a979067fb1c18cb3c # not set in build() when image= is used
 	cd "$srcdir/netsurf-reMarkable-$_commit"
 	# Remove the toolchain's prebuilt shared libevdev so the linker uses the
 	# static one install_dependencies.sh builds instead.

--- a/packages/oxide/VELBUILD
+++ b/packages/oxide/VELBUILD
@@ -15,7 +15,7 @@ launcherctl-oxide:launcherctl_oxide
 '
 pkgname=oxide
 pkgver="3.1.2"
-pkgrel=0
+pkgrel=1
 upstream_author="Eeems-Org"
 maintainer="Eeems <eeems@eeems.email>"
 url=https://oxide.eeems.codes
@@ -32,6 +32,7 @@ oxide-display=$pkgver-r$pkgrel
 liboxide=$pkgver-r$pkgrel
 "
 provides="launcher"
+options='strip'
 
 _toolchain=5.7.119
 image() {
@@ -46,19 +47,14 @@ image() {
 }
 
 build() {
-    _toolchain=5.7.119 # Is not currently passed into build()
     set -e
     cd "$srcdir"/oxide-"$pkgver"
     . "$ENVIRONMENT_SETUP"
     make FEATURES=sentry release
-    find release -type f -print0 | xargs -0 sh -c '
-        for f; do
-            file -b "$f" | grep -q ELF && printf "%s\0" "$f"
-        done
-    ' _ | xargs -0 "$STRIP" --strip-unneeded
 }
 
 package() {
+    set -e
     cd "$srcdir"/oxide-"$pkgver"/release
     # System service
     install -o root -g root -Dm644 -t "$pkgdir"/home/root/.vellum/share/oxide/dbus-1/system.d \

--- a/packages/qtfblight/VELBUILD
+++ b/packages/qtfblight/VELBUILD
@@ -4,7 +4,7 @@ appload-to-oxide:appload_to_oxide
 maintainer="Noa Himesaka <himesaka@noa.codes>"
 pkgname=qtfblight
 pkgver=0.1.2
-pkgrel=0
+pkgrel=1
 pkgdesc="QTFB compatibility server for reMarkable tablets"
 upstream_author="NoaHimesaka1873"
 category="framework"
@@ -14,9 +14,11 @@ license="GPL-3.0-only"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/$pkgname/$pkgver/README.md"
 source="$pkgname-$pkgver.zip::https://github.com/$upstream_author/$pkgname/archive/refs/tags/$pkgver.zip"
 depends="oxide-display"
+options='strip'
 
 image="ghcr.io/toltec-dev/rust:v4.0"
 build() {
+	set -e
 	case "$CARCH" in
 	aarch64) . /opt/x-tools/switch-aarch64.sh ;;
 	armv7) . /opt/x-tools/switch-arm.sh ;;
@@ -31,10 +33,10 @@ build() {
 
 	mv target/"$CARGO_BUILD_TARGET"/release/qtfblight .
 	mv target/"$CARGO_BUILD_TARGET"/release/appload-to-oxide .
-	"${CROSS_COMPILE}strip" qtfblight appload-to-oxide
 }
 
 package() {
+	set -e
 	cd "$srcdir/$pkgname-$pkgver"
 
 	install -Dm755 qtfblight \
@@ -55,6 +57,7 @@ appload_to_oxide() {
 	"
 
 	package() {
+		set -e
 		cd "$srcdir/$pkgname-$pkgver"
 
 		install -Dm755 appload-to-oxide \

--- a/packages/remarkdown/VELBUILD
+++ b/packages/remarkdown/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="esclee <5288860+esclee@users.noreply.github.com>"
 pkgname=remarkdown
 pkgver=0.3.0
-pkgrel=0
+pkgrel=1
 upstream_author="esclee"
 category="apps"
 pkgdesc="A lightweight Markdown editor for the reMarkable tablet, to be used via AppLoad"
@@ -14,6 +14,7 @@ readmeurl="https://raw.githubusercontent.com/$upstream_author/reMarkdown/v$pkgve
 source="
 reMarkdown-$pkgver.tar.gz::https://github.com/$upstream_author/reMarkdown/archive/refs/tags/v$pkgver.tar.gz
 "
+options='strip'
 
 image() {
 	case "$CARCH" in
@@ -43,10 +44,10 @@ build() {
 	esac
 	PATH="${OECORE_NATIVE_SYSROOT}/usr/libexec:$PATH" \
 		bash -e ./build.sh "$arch"
-	"$STRIP" --strip-unneeded rmd/backend/entry
 }
 
 package() {
+	set -e
 	cd "$srcdir"/reMarkdown-"$pkgver"
 	install -d "$pkgdir"/home/root/xovi/exthome/appload
 	cp -r rmd "$pkgdir"/home/root/xovi/exthome/appload
@@ -56,6 +57,7 @@ package() {
 }
 
 postdeinstall() {
+	set -e
 	if [ "$VELLUM_PURGE" = "1" ]; then
 		rm -rf /home/root/xovi/exthome/appload/rmd
 	fi

--- a/packages/restream/VELBUILD
+++ b/packages/restream/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=restream
 pkgver=1.5.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Binary framebuffer capture tool for the reStream script"
 upstream_author="rien"
 category="utilities"
@@ -10,9 +10,10 @@ arch="armv7"
 license="MIT"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/reStream/v$pkgver/README.md"
 source="$pkgname-$pkgver.tar.gz::https://github.com/$upstream_author/reStream/archive/refs/tags/v$pkgver.tar.gz"
-
+options='strip'
 image="ghcr.io/toltec-dev/rust:v4.0"
 build() {
+	set -e
 	case "$CARCH" in
 	# aarch64) . /opt/x-tools/switch-aarch64.sh ;;  # Not supported currently
 	armv7) . /opt/x-tools/switch-arm.sh ;;
@@ -23,11 +24,11 @@ build() {
 	esac
 	cd "$srcdir/reStream-$pkgver"
 	cargo build --release --bin restream
-	"${CROSS_COMPILE}strip" target/"$CARGO_BUILD_TARGET"/release/restream
 	mv target/"$CARGO_BUILD_TARGET"/release/restream .
 }
 
 package() {
+	set -e
 	cd "$srcdir/reStream-$pkgver"
 	install -Dm644 "LICENSE" \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"

--- a/packages/zerotier-one/VELBUILD
+++ b/packages/zerotier-one/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Nathaniel van Diepen <eeems@eeems.email>"
 pkgname=zerotier-one
 pkgver=1.16.2
-pkgrel=0
+pkgrel=1
 pkgdesc="A Smart Ethernet Switch for Earth"
 upstream_author="zerotier"
 category="utilities"
@@ -12,10 +12,11 @@ readmeurl="https://raw.githubusercontent.com/$upstream_author/ZeroTierOne/$pkgve
 source="$pkgname-$pkgver.tar.gz::https://github.com/$upstream_author/ZeroTierOne/archive/refs/tags/$pkgver.tar.gz"
 subpackages="zerotier-selftest:selftest"
 systemdunits="ZeroTierOne-$pkgver/debian/zerotier-one.service"
+options='strip'
 
 image="ghcr.io/toltec-dev/base:v4.0"
 build() {
-	set -xe
+	set -e
 	case "$CARCH" in
 	aarch64) . /opt/x-tools/switch-aarch64.sh ;;
 	armv7) . /opt/x-tools/switch-arm.sh ;;
@@ -52,6 +53,7 @@ build() {
 }
 
 package() {
+	set -e
 	cd "$srcdir/ZeroTierOne-$pkgver"
 	install -Dm644 "LICENSE-MPL.txt" \
 		"$pkgdir/home/root/.vellum/licenses/$pkgname/LICENSE"
@@ -63,6 +65,7 @@ package() {
 doc() {
 	pkgdesc="Man files for zerotier-one"
 	package() {
+		set -e
 		mkdir -p "$subpkgdir"/home/root/.vellum/share
 		mv "$pkgdir"/home/root/.vellum/share/. "$subpkgdir"/home/root/.vellum/share
 	}
@@ -70,6 +73,7 @@ doc() {
 selftest() {
 	pkgdesc="Unit test zerotier to ensure that it works as expected on the system"
 	package() {
+		set -e
 		cd "$srcdir/ZeroTierOne-$pkgver"
 		install -Dm755 zerotier-selftest \
 			"$subpkgdir"/home/root/.vellum/bin/zerotier-selftest


### PR DESCRIPTION
- Allow local variables in lifecycle scripts
- Properly pass all VELBUILD variables to build script
- Use `${STRIP:-${CROSS_COMPILE}strip}` for stripping when `options='strip'` instead of abuild strip