### PR TITLE
pitwall: 1.1.0

### DIFF
--- a/packages/pitwall/VELBUILD
+++ b/packages/pitwall/VELBUILD
@@ -3,7 +3,7 @@ pitwall-oxide:pitwall_oxide
 '
 maintainer="Yan Khachko <a@slnk.icu>"
 pkgname=pitwall
-pkgver=1.0.1
+pkgver=1.1.0
 pkgrel=0
 upstream_author="sijokun"
 category="apps"
@@ -12,7 +12,7 @@ url="https://github.com/$upstream_author/PitWall"
 arch="aarch64 armv7"
 license="MIT"
 depends="launcher"
-_commit="aefee2e93c4b7f9e0f865adfc5f78e06f392b959"
+_commit="f8c1b42dbf42f9e59dbc41fd914d35ce84bd2392"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/PitWall/$_commit/README.md"
 
 source="
@@ -71,7 +71,7 @@ postdeinstall() {
 	fi
 }
 
-sha512sums='855159296df709430db4ee290d416a9eda271797a6d95af93ce71241b39e413bd5256d86074755e8dcb581cc7a0e8c5c93701da0f1283120a8b390f2be613356
-pitwall-1.0.1.tar.gz
+sha512sums='8fd7724064b7c11f5e1fc89685326628ee590f1e194a7ad5ff5626687d7b24a389d4318976e0de05ceff9f0e20a568810e4da85573ea677a47b11f83b9450cde
+pitwall-1.1.0.tar.gz
 1dc3014f9063cb557ab66bcd7806e00142f4e36f44ad52e2bbbdf0558aaf78e628318c459853bbd5b4e666a520742dd9461418764010a5fd7da821df4e21cc02
 pitwall.oxide'


### PR DESCRIPTION
# PitWall to 1.1.0

## Changelog
 - Mini-sectors on the timing tab and map
 - paged race control
 - paged settings
 - per-lap colored track map in the driver popup
 - clock timezone setting.


## Images
Images are from emulator, but it was tested on my RMPP
<img width="922" height="1220" alt="Screenshot 2026-09-02 at 19 55 23" src="https://github.com/user-attachments/assets/0d9be084-210c-4863-8865-1ab6507432a2" />

<img width="922" height="1220" alt="Screenshot 2026-09-02 at 19 55 32" src="https://github.com/user-attachments/assets/342acc4f-9731-4026-b0b2-f1879de0ff89" />

<img width="922" height="1220" alt="Screenshot 2026-09-02 at 19 55 36" src="https://github.com/user-attachments/assets/8226ee22-f895-4ce7-a303-cd2d8b483398" />


### on device:
<img width="1266" height="951" alt="Screenshot 2026-09-02 at 20 11 37" src="https://github.com/user-attachments/assets/eaf9e9cc-9868-4adc-9d9b-e842e8fe968d" />
