### PR TITLE
toolbar-icon: fix depends for 3.28

### DIFF
--- a/packages/toolbar-icon/VELBUILD
+++ b/packages/toolbar-icon/VELBUILD
@@ -1,7 +1,7 @@
 maintainer="Fouz Reda <fouz290903@gmail.com>"
 pkgname=toolbar-icon
 pkgver=1.1.1
-pkgrel=0
+pkgrel=1
 upstream_author="FouzR"
 category="ui"
 pkgdesc="Adds an icon with current tool, thickness, and colour in place of the toolbar-expand button while the toolbar is hidden."

--- a/packages/toolbar-icon/VELBUILD
+++ b/packages/toolbar-icon/VELBUILD
@@ -8,7 +8,7 @@ pkgdesc="Adds an icon with current tool, thickness, and colour in place of the t
 url="https://github.com/FouzR/xovi-extensions"
 arch="noarch"
 license="GPL-3.0"
-depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
+depends="qt-resource-rebuilder remarkable-os>=3.28 remarkable-os<3.29"
 _commit="5db4cb6d1e5d43f8ea8484c77ab08b8a15f2640a"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-extensions/$_commit/README.md"
 donateurl="https://ko-fi.com/fouzr"


### PR DESCRIPTION
Somehow this slips from the https://github.com/vellum-dev/vellum/pull/349