### PR TITLE
Mods aligned to version 3.28

### DIFF
--- a/packages/collapse-toolbar-on-open/VELBUILD
+++ b/packages/collapse-toolbar-on-open/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=collapse-toolbar-on-open
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,12 +8,12 @@ pkgdesc="Opens every document with the toolbar collapsed"
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
-_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+depends="qt-resource-rebuilder remarkable-os>=3.28 remarkable-os<3.29"
+_commit="3bae56d51fd4f14b4bde87f2cfbc292af25ae9f6"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#collapsetoolbaronopen"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/collapseToolbarOnOpen.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.28/collapseToolbarOnOpen.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options='strip tracedeps'
@@ -28,6 +28,6 @@ package() {
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
 }
 sha512sums="
-c3a4b2763906fcf564bdca1af50f765578e6662a1ca7e559ecf8ef3909c2c97997becdd6d783069a13ec88f80c7beae2347c0330f6ea781c7f4da0cadc69b71b  collapseToolbarOnOpen.qmd
+71f7db9226f31a0f7badf385206dcc987a10c4e378b0fbad4cb0da1d33ee9b4324c68aa4b03fb709115fc3479c61b48985247ad23d53fd8dddd97c78451b60ca  collapseToolbarOnOpen.qmd
 6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
 "

--- a/packages/dictionary-wiki-translator/VELBUILD
+++ b/packages/dictionary-wiki-translator/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=dictionary-wiki-translator
-pkgver=1.0.1
+pkgver=1.1.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,12 +8,12 @@ pkgdesc="Adds integrated dictionary, Wikipedia, and translation capabilities for
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder qt-command-executor remarkable-os>=3.25 remarkable-os<3.28"
-_commit="ac44f719293a904c50904515597c8da8b5779cd2"
+depends="qt-resource-rebuilder qt-command-executor remarkable-os>=3.28 remarkable-os<3.29"
+_commit="3bae56d51fd4f14b4bde87f2cfbc292af25ae9f6"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#dictionary"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/dictionaryWikiTranslator.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.28/dictionaryWikiTranslator.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="!check !fhs"
@@ -36,6 +36,6 @@ postdeinstall() {
 }
 
 sha512sums="
-4d3e8971c4cd1a15a0e8db30eb52461c0a9ee08ca6995b13854efe49131cd6c1669785ad830ef70d83895332b20a6f555ffdd39115b119e4934aa273010cd6b5  dictionaryWikiTranslator.qmd
+b073290da663a9178ec7152ecaf7add0df872f239a3910f29bc386b76e11c936c4d0bd076f798c7c3afcf4f05ced71bc92ba0bdeeece6a0e72ae21bf9def49bc  dictionaryWikiTranslator.qmd
 6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
 "

--- a/packages/dock-buttons/VELBUILD
+++ b/packages/dock-buttons/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=dock-buttons
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,12 +8,12 @@ pkgdesc="Adds My Files / Favorites / Tags / Trash shortcut buttons to the homepa
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder !fav-tag-button remarkable-os>=3.27 remarkable-os<3.28"
-_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+depends="qt-resource-rebuilder !fav-tag-button remarkable-os>=3.28 remarkable-os<3.29"
+_commit="3bae56d51fd4f14b4bde87f2cfbc292af25ae9f6"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#dockbuttons"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/dockButtons.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.28/dockButtons.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options='strip tracedeps'

--- a/packages/faster-page-labels/VELBUILD
+++ b/packages/faster-page-labels/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=faster-page-labels
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,12 +8,12 @@ pkgdesc="Auto-hides the page-number label ~1.25s after a page turn"
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
-_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+depends="qt-resource-rebuilder remarkable-os>=3.28 remarkable-os<3.29"
+_commit="3bae56d51fd4f14b4bde87f2cfbc292af25ae9f6"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#fasterpagelabels"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/fasterPageLabels.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.28/fasterPageLabels.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options='strip tracedeps'

--- a/packages/faster-scroll-bar/VELBUILD
+++ b/packages/faster-scroll-bar/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=faster-scroll-bar
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,12 +8,12 @@ pkgdesc="Auto-hides the document scrollbar ~0.35s after you stop scrolling"
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder remarkable-os>=3.22 remarkable-os<3.28"
-_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+depends="qt-resource-rebuilder remarkable-os>=3.28 remarkable-os<3.29"
+_commit="3bae56d51fd4f14b4bde87f2cfbc292af25ae9f6"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#fasterscrollbar"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/fasterScrollBar.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.28/fasterScrollBar.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options='strip tracedeps'

--- a/packages/force-wide-column/VELBUILD
+++ b/packages/force-wide-column/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=force-wide-column
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,12 +8,12 @@ pkgdesc="Forces a note's typed text to the Wide column on open, including existi
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
-_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+depends="qt-resource-rebuilder remarkable-os>=3.28 remarkable-os<3.29"
+_commit="3bae56d51fd4f14b4bde87f2cfbc292af25ae9f6"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#forcewidecolumn"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/forceWideColumn.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.28/forceWideColumn.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="strip tracedeps"

--- a/packages/gestik/VELBUILD
+++ b/packages/gestik/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=gestik
-pkgver=1.1.2
+pkgver=1.2.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,12 +8,12 @@ pkgdesc="Configurable multi-finger gestures for tool switching or action you wan
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder !gestures-fouzr !gestures-ingatellent !four-finger-change-filter !three-finger-swipe-to-reset-view remarkable-os>=3.25 remarkable-os<3.28"
-_commit="ac44f719293a904c50904515597c8da8b5779cd2"
+depends="qt-resource-rebuilder !gestures-fouzr !gestures-ingatellent !four-finger-change-filter !three-finger-swipe-to-reset-view remarkable-os>=3.28 remarkable-os<3.29"
+_commit="3bae56d51fd4f14b4bde87f2cfbc292af25ae9f6"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#gestik"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/gestik.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.28/gestik.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="strip tracedeps"
@@ -35,6 +35,6 @@ postdeinstall() {
 }
 
 sha512sums="
-92de946d833e0c4617fca3ecfe70bfe16f0f01301c470107c1b8033c7cfec263fcc34ea98ee17f56cf0921c53e77bfe6d2db8f5b1d9f1527bec603097a0bf574  gestik.qmd
+336d5c557b963958bf66f7176277f62f5c4db622e7702ca73e4330db0837ea309c092b142ad7deadc772a9017c038c577e8eec950872ce09946070678c27a47a  gestik.qmd
 6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
 "

--- a/packages/hide-back-to-page-bar/VELBUILD
+++ b/packages/hide-back-to-page-bar/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=hide-back-to-page-bar
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,12 +8,12 @@ pkgdesc="Hides the native Back-to-page-N bar shown after following a PDF hyperli
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder !hide-hyperlink-back-button remarkable-os>=3.27 remarkable-os<3.28"
-_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+depends="qt-resource-rebuilder !hide-hyperlink-back-button remarkable-os>=3.28 remarkable-os<3.29"
+_commit="3bae56d51fd4f14b4bde87f2cfbc292af25ae9f6"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#hidebacktopagebar"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/hideBackToPageBar.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.28/hideBackToPageBar.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="strip tracedeps"

--- a/packages/hide-title-quick-browse/VELBUILD
+++ b/packages/hide-title-quick-browse/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=hide-title-quick-browse
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,12 +8,12 @@ pkgdesc="Hides the document-title bar shown while the quick-browse page-slider i
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
-_commit="7c035706ac184ebaf6faaca01d40cf1d2391210f"
+depends="qt-resource-rebuilder remarkable-os>=3.28 remarkable-os<3.29"
+_commit="3bae56d51fd4f14b4bde87f2cfbc292af25ae9f6"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#hidetitlequickbrowse"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/hideTitleQuickBrowse.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.28/hideTitleQuickBrowse.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="strip tracedeps"

--- a/packages/link-from-selection/VELBUILD
+++ b/packages/link-from-selection/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=link-from-selection
-pkgver=1.1.0
+pkgver=1.2.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,12 +8,12 @@ pkgdesc="On-page links from a lasso selection: jump to a page in this or another
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
-_commit="0054787b771b292359867c88b0a2df1b6e996a97"
+depends="qt-resource-rebuilder remarkable-os>=3.28 remarkable-os<3.29"
+_commit="3bae56d51fd4f14b4bde87f2cfbc292af25ae9f6"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#linkfromselection"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/linkFromSelection.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.28/linkFromSelection.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="strip tracedeps"
@@ -28,6 +28,6 @@ package() {
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
 }
 sha512sums="
-7052271bc6416013e6c9a32037d39296145ec6ae56b18c9a2f13506ab4e45ebc8fd2f2ec39fb5b5394aae170235f9fc0ce7980d11560dd9b65767ed1e60d608b  linkFromSelection.qmd
+409c809b346c87ce885f58647685b063fc155f17f28d73c572ce09b3a971f77a8206536cc65eb9617755039402f745e566614884852ed557c2df7a1584c5950c  linkFromSelection.qmd
 6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
 "

--- a/packages/nav-history/VELBUILD
+++ b/packages/nav-history/VELBUILD
@@ -1,6 +1,6 @@
 maintainer="Alessio Faraci <contact@afaraci.com>"
 pkgname=nav-history
-pkgver=1.1.0
+pkgver=1.2.0
 pkgrel=0
 upstream_author="alefaraci"
 category="ui"
@@ -8,12 +8,12 @@ pkgdesc="Back & Forward navigation through your visited-page history"
 url="https://github.com/alefaraci/xovi-qmd-extensions"
 arch="noarch"
 license="GPL-3.0-only"
-depends="qt-resource-rebuilder remarkable-os>=3.27 remarkable-os<3.28"
-_commit="1e7392ad13a563b5149eb03cc1ef24c4fca2e498"
+depends="qt-resource-rebuilder remarkable-os>=3.28 remarkable-os<3.29"
+_commit="3bae56d51fd4f14b4bde87f2cfbc292af25ae9f6"
 readmeurl="https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/README.md#navhistory"
 donateurl="https://buymeacoffee.com/afaraci"
 source="
-https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.27/navHistory.qmd
+https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/3.28/navHistory.qmd
 https://raw.githubusercontent.com/$upstream_author/xovi-qmd-extensions/$_commit/LICENSE
 "
 options="strip tracedeps"
@@ -28,6 +28,6 @@ package() {
 		"$pkgdir"/home/root/.vellum/licenses/$pkgname/SOURCES
 }
 sha512sums="
-17601c7f1df5f595d337910bec31b8be31163d7f54c2c8aeaf9bcce338070052c75bb736dc0af942e619b05ec2d6de0afeac67a8bbf45ee713976812223ae212  navHistory.qmd
+08b5772f1a744a62e8d554e8efff5d226ca908c24e193435afe9e906d8b7c5e715808ef5a2a6fd44a56169f4a84b854a8189c54d1f5d6afaf95d130fef0bd0fc  navHistory.qmd
 6dbfcd77cdf7d1b8bede7d6c7b2d61943033da1bdd675a419af2f183798f7ece774fa9ae0b189d92200065704be2ba11fa0966e3f1d6edf9ffbb1b61cf60c73e  LICENSE
 "


### PR DESCRIPTION
Mods aligned to version 3.28:

- collapse-toolbar-on-open
- dictionary-wiki-translator
- dock-buttons
- faster-page-labels
- faster-scroll-bar
- force-wide-column
- gestik
- hide-back-to-page-bar
- hide-title-quick-browse
- link-from-selection
- nav-history


Tested on rM Paper Pure.


<img width="900" alt="Screenshot 2026-09-11 alle 14 13 11" src="https://github.com/user-attachments/assets/1e8eb2a1-d34b-43fa-b4a3-e2fd9162963f" />
